### PR TITLE
ci: bump openssl dependencies

### DIFF
--- a/build/deps/crates/cargo-bazel-lock.json
+++ b/build/deps/crates/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "492b8c1958cabb62184b075ccc8c0a4932b9378e9da18bc7962df4050431d103",
+  "checksum": "7512ad9215498d677f228ba9c09d224a317ae1fc04c6c911c2cc8f02f2ebe216",
   "crates": {
     "abscissa_core 0.6.0": {
       "name": "abscissa_core",
@@ -2202,11 +2202,11 @@
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.45",
+              "id": "openssl 0.10.48",
               "target": "openssl"
             },
             {
-              "id": "openssl-sys 0.9.80",
+              "id": "openssl-sys 0.9.83",
               "target": "openssl_sys"
             },
             {
@@ -3454,7 +3454,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.80",
+                "id": "openssl-sys 0.9.83",
                 "target": "openssl_sys"
               }
             ]
@@ -3531,7 +3531,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.80",
+                "id": "openssl-sys 0.9.83",
                 "target": "openssl_sys"
               }
             ]
@@ -4558,7 +4558,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "openssl-sys 0.9.80",
+                "id": "openssl-sys 0.9.83",
                 "target": "openssl_sys"
               }
             ]
@@ -4612,7 +4612,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "openssl-sys 0.9.80",
+                "id": "openssl-sys 0.9.83",
                 "target": "openssl_sys"
               }
             ]
@@ -5329,13 +5329,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "openssl 0.10.45": {
+    "openssl 0.10.48": {
       "name": "openssl",
-      "version": "0.10.45",
+      "version": "0.10.48",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl/0.10.45/download",
-          "sha256": "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+          "url": "https://crates.io/api/v1/crates/openssl/0.10.48/download",
+          "sha256": "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
         }
       },
       "targets": [
@@ -5392,11 +5392,11 @@
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.45",
+              "id": "openssl 0.10.48",
               "target": "build_script_build"
             },
             {
-              "id": "openssl-sys 0.9.80",
+              "id": "openssl-sys 0.9.83",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -5413,7 +5413,7 @@
           ],
           "selects": {}
         },
-        "version": "0.10.45"
+        "version": "0.10.48"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5422,7 +5422,7 @@
         "deps": {
           "common": [
             {
-              "id": "openssl-sys 0.9.80",
+              "id": "openssl-sys 0.9.83",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -5509,13 +5509,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "openssl-sys 0.9.80": {
+    "openssl-sys 0.9.83": {
       "name": "openssl-sys",
-      "version": "0.9.80",
+      "version": "0.9.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.80/download",
-          "sha256": "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.83/download",
+          "sha256": "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
         }
       },
       "targets": [
@@ -5556,7 +5556,7 @@
               "target": "libc"
             },
             {
-              "id": "openssl-sys 0.9.80",
+              "id": "openssl-sys 0.9.83",
               "target": "build_script_main"
             }
           ],
@@ -5565,8 +5565,8 @@
         "extra_deps": [
           "@openssl"
         ],
-        "edition": "2015",
-        "version": "0.9.80"
+        "edition": "2018",
+        "version": "0.9.83"
       },
       "build_script_attrs": {
         "data": {

--- a/build/deps/crates/cargo.lock
+++ b/build/deps/crates/cargo.lock
@@ -983,9 +983,9 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1015,9 +1015,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/build/deps/crates/crates_repositories.bzl
+++ b/build/deps/crates/crates_repositories.bzl
@@ -42,10 +42,10 @@ _packages = {
         version = "0.2",
     ),
     "openssl": crate.spec(
-        version = "0.10",
+        version = "0.10.48",
     ),
     "openssl-sys": crate.spec(
-        version = "0.9",
+        version = "0.9.83",
     ),
     "ssh2": crate.spec(
         version = "0.9",


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2023-0022
https://rustsec.org/advisories/RUSTSEC-2023-0023
