### PR TITLE
build: bump rules_rust to v0.21.1

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -44,8 +44,8 @@ rules_foreign_cc_dependencies()
 # Rust
 http_archive(
     name = "rules_rust",
-    sha256 = "b4e622a36904b5dd2d2211e40008fc473421c8b51c9efca746ab2ecf11dca08e",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.19.1/rules_rust-v0.19.1.tar.gz"],
+    sha256 = "25209daff2ba21e818801c7b2dab0274c43808982d6aea9f796d899db6319146",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.21.1/rules_rust-v0.21.1.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")

--- a/toolchain.bzl
+++ b/toolchain.bzl
@@ -1,7 +1,7 @@
 RUST_STABLE_VERSION = "1.68.2"
 
 # https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly
-RUST_NIGHTLY_VERSION = "nightly/2023-03-25"
+RUST_NIGHTLY_VERSION = "nightly/2023-04-25"
 
 RUST_VERSIONS = [
     RUST_STABLE_VERSION,


### PR DESCRIPTION
- build: bump rules_rust to v0.21.1
- build: bump nightly to 2023-04-25
