### PR TITLE
build/deps/crastes: delete rust_version from lib_crates.repository

### DIFF
--- a/build/deps/repositories.bzl
+++ b/build/deps/repositories.bzl
@@ -58,6 +58,9 @@ def build_dependencies():
         # The version of Rust the currently registered toolchain is using.
         rust_version = RUST_STABLE_VERSION,
         splicing_config = splicing_config(
+            # The resolver version to use in generated Cargo manifests.
+            # This flag is only used when splicing a manifest from direct package definitions.
+            # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
             resolver_version = "2",
         ),
     )

--- a/build/deps/repositories.bzl
+++ b/build/deps/repositories.bzl
@@ -55,8 +55,6 @@ def build_dependencies():
 
     # CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=lib_crates bazel sync --only=lib_crates
     lib_crates.repository(
-        # The version of Rust the currently registered toolchain is using.
-        rust_version = RUST_STABLE_VERSION,
         splicing_config = splicing_config(
             # The resolver version to use in generated Cargo manifests.
             # This flag is only used when splicing a manifest from direct package definitions.


### PR DESCRIPTION
By default, this setting seems to be completely meaningless
for toolchain resolution.

http://bazelbuild.github.io/rules_rust/crate_universe.html#crates_repository-rust_toolchain_cargo_template
http://bazelbuild.github.io/rules_rust/crate_universe.html#crates_repository-rust_toolchain_rustc_template
