### PR TITLE
ci: fix RUSTSEC-2023-0064

### DIFF
--- a/build/deps/crates/Cargo.Bazel.lock
+++ b/build/deps/crates/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b7b9f593b9754cea0d382a73e8f136c483fe66f8d1754efbe4440d23b423cdaa",
+  "checksum": "cb55976e3405877897d6962a0b8f8521fe8b13fe6a5c6b37552dc569713bf2f7",
   "crates": {
     "abscissa_core 0.6.0": {
       "name": "abscissa_core",
@@ -262,92 +262,6 @@
         "version": "1.0.2"
       },
       "license": "0BSD OR MIT OR Apache-2.0"
-    },
-    "ahash 0.8.3": {
-      "name": "ahash",
-      "version": "0.8.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ahash/0.8.3/download",
-          "sha256": "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ahash",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ahash",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "getrandom",
-            "runtime-rng",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ahash 0.8.3",
-              "target": "build_script_build"
-            },
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "getrandom 0.2.10",
-              "target": "getrandom"
-            }
-          ],
-          "selects": {
-            "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
-              {
-                "id": "once_cell 1.18.0",
-                "target": "once_cell"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.8.3"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "aho-corasick 1.0.2": {
       "name": "aho-corasick",
@@ -814,36 +728,6 @@
         ],
         "edition": "2018",
         "version": "1.6.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "arrayvec 0.7.4": {
-      "name": "arrayvec",
-      "version": "0.7.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/arrayvec/0.7.4/download",
-          "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "arrayvec",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "arrayvec",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.7.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2165,13 +2049,13 @@
       },
       "license": "Apache-2.0"
     },
-    "cargo-audit 0.18.1": {
+    "cargo-audit 0.18.2": {
       "name": "cargo-audit",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cargo-audit/0.18.1/download",
-          "sha256": "98bf8e948b35c7e5c715db6a7e82c7eccb8ec722965287b59f3ac15431288f9b"
+          "url": "https://crates.io/api/v1/crates/cargo-audit/0.18.2/download",
+          "sha256": "596642f33fd57a8014990a19a449473184938642d8011b6e27a5ad50195c5e09"
         }
       },
       "targets": [
@@ -2245,7 +2129,7 @@
               "target": "quitters"
             },
             {
-              "id": "rustsec 0.28.1",
+              "id": "rustsec 0.28.2",
               "target": "rustsec"
             },
             {
@@ -2264,7 +2148,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.1"
+        "version": "0.18.2"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -3260,77 +3144,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam 0.8.2": {
-      "name": "crossbeam",
-      "version": "0.8.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam/0.8.2/download",
-          "sha256": "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crossbeam",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "crossbeam",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "crossbeam-channel",
-            "crossbeam-deque",
-            "crossbeam-epoch",
-            "crossbeam-queue",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "crossbeam-channel 0.5.8",
-              "target": "crossbeam_channel"
-            },
-            {
-              "id": "crossbeam-deque 0.8.3",
-              "target": "crossbeam_deque"
-            },
-            {
-              "id": "crossbeam-epoch 0.9.15",
-              "target": "crossbeam_epoch"
-            },
-            {
-              "id": "crossbeam-queue 0.3.8",
-              "target": "crossbeam_queue"
-            },
-            {
-              "id": "crossbeam-utils 0.8.16",
-              "target": "crossbeam_utils"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.2"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "crossbeam-channel 0.5.8": {
       "name": "crossbeam-channel",
       "version": "0.5.8",
@@ -3520,74 +3333,6 @@
           ],
           "selects": {}
         }
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "crossbeam-queue 0.3.8": {
-      "name": "crossbeam-queue",
-      "version": "0.3.8",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-queue/0.3.8/download",
-          "sha256": "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crossbeam_queue",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "crossbeam_queue",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "crossbeam-queue 0.3.8",
-              "target": "build_script_build"
-            },
-            {
-              "id": "crossbeam-utils 0.8.16",
-              "target": "crossbeam_utils"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.8"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3868,7 +3613,7 @@
               "target": "bitflags"
             },
             {
-              "id": "cargo-audit 0.18.1",
+              "id": "cargo-audit 0.18.2",
               "target": "cargo_audit"
             },
             {
@@ -5723,13 +5468,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix 0.52.0": {
+    "gix 0.53.1": {
       "name": "gix",
-      "version": "0.52.0",
+      "version": "0.53.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix/0.52.0/download",
-          "sha256": "a35ed1401a11506b45361746507a7c94c546574ddd7dfc2717f8941e30070254"
+          "url": "https://crates.io/api/v1/crates/gix/0.53.1/download",
+          "sha256": "06a8c9f9452078f474fecd2880de84819b8c77224ab62273275b646bf785f906"
         }
       },
       "targets": [
@@ -5750,145 +5495,147 @@
         ],
         "crate_features": {
           "common": [
+            "attributes",
             "blocking-http-transport-reqwest",
             "blocking-network-client",
+            "credentials",
+            "excludes",
             "gix-protocol",
             "gix-transport",
-            "max-performance-safe",
-            "pack-cache-lru-dynamic",
-            "pack-cache-lru-static",
-            "reqwest-for-configuration-only"
+            "index",
+            "revision",
+            "worktree-mutation"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "gix-actor 0.25.0",
+              "id": "gix-actor 0.26.0",
               "target": "gix_actor"
             },
             {
-              "id": "gix-attributes 0.17.0",
+              "id": "gix-attributes 0.18.0",
               "target": "gix_attributes"
             },
             {
-              "id": "gix-commitgraph 0.19.0",
+              "id": "gix-commitgraph 0.20.0",
               "target": "gix_commitgraph"
             },
             {
-              "id": "gix-config 0.28.0",
+              "id": "gix-config 0.29.0",
               "target": "gix_config"
             },
             {
-              "id": "gix-credentials 0.18.0",
+              "id": "gix-credentials 0.19.0",
               "target": "gix_credentials"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-diff 0.34.0",
+              "id": "gix-diff 0.35.0",
               "target": "gix_diff"
             },
             {
-              "id": "gix-discover 0.23.0",
+              "id": "gix-discover 0.24.0",
               "target": "gix_discover"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-filter 0.3.0",
+              "id": "gix-filter 0.4.0",
               "target": "gix_filter"
             },
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-hashtable 0.3.0",
+              "id": "gix-hashtable 0.4.0",
               "target": "gix_hashtable"
             },
             {
-              "id": "gix-ignore 0.6.0",
+              "id": "gix-ignore 0.7.0",
               "target": "gix_ignore"
             },
             {
-              "id": "gix-index 0.22.0",
+              "id": "gix-index 0.24.0",
               "target": "gix_index"
             },
             {
-              "id": "gix-lock 8.0.0",
+              "id": "gix-lock 9.0.0",
               "target": "gix_lock"
             },
             {
-              "id": "gix-mailmap 0.17.0",
-              "target": "gix_mailmap"
-            },
-            {
-              "id": "gix-negotiate 0.6.0",
+              "id": "gix-negotiate 0.7.0",
               "target": "gix_negotiate"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-odb 0.51.0",
+              "id": "gix-odb 0.52.0",
               "target": "gix_odb"
             },
             {
-              "id": "gix-pack 0.41.0",
+              "id": "gix-pack 0.42.0",
               "target": "gix_pack"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-pathspec 0.1.0",
+              "id": "gix-pathspec 0.2.0",
               "target": "gix_pathspec"
             },
             {
-              "id": "gix-prompt 0.6.0",
+              "id": "gix-prompt 0.7.0",
               "target": "gix_prompt"
             },
             {
-              "id": "gix-protocol 0.38.0",
+              "id": "gix-protocol 0.39.0",
               "target": "gix_protocol"
             },
             {
-              "id": "gix-ref 0.35.0",
+              "id": "gix-ref 0.36.0",
               "target": "gix_ref"
             },
             {
-              "id": "gix-refspec 0.16.0",
+              "id": "gix-refspec 0.17.0",
               "target": "gix_refspec"
             },
             {
-              "id": "gix-revision 0.20.0",
+              "id": "gix-revision 0.21.0",
               "target": "gix_revision"
             },
             {
-              "id": "gix-sec 0.9.0",
+              "id": "gix-revwalk 0.7.0",
+              "target": "gix_revwalk"
+            },
+            {
+              "id": "gix-sec 0.10.0",
               "target": "gix_sec"
             },
             {
-              "id": "gix-submodule 0.2.0",
+              "id": "gix-submodule 0.3.0",
               "target": "gix_submodule"
             },
             {
-              "id": "gix-tempfile 8.0.0",
+              "id": "gix-tempfile 9.0.0",
               "target": "gix_tempfile"
             },
             {
@@ -5896,15 +5643,15 @@
               "target": "gix_trace"
             },
             {
-              "id": "gix-transport 0.35.0",
+              "id": "gix-transport 0.36.1",
               "target": "gix_transport"
             },
             {
-              "id": "gix-traverse 0.31.0",
+              "id": "gix-traverse 0.32.0",
               "target": "gix_traverse"
             },
             {
-              "id": "gix-url 0.22.0",
+              "id": "gix-url 0.23.0",
               "target": "gix_url"
             },
             {
@@ -5916,16 +5663,12 @@
               "target": "gix_validate"
             },
             {
-              "id": "gix-worktree 0.24.0",
+              "id": "gix-worktree 0.25.0",
               "target": "gix_worktree"
             },
             {
-              "id": "gix-worktree-state 0.1.0",
+              "id": "gix-worktree-state 0.2.0",
               "target": "gix_worktree_state"
-            },
-            {
-              "id": "log 0.4.19",
-              "target": "log"
             },
             {
               "id": "once_cell 1.18.0",
@@ -5934,15 +5677,6 @@
             {
               "id": "parking_lot 0.12.1",
               "target": "parking_lot"
-            },
-            {
-              "id": "reqwest 0.11.20",
-              "target": "reqwest",
-              "alias": "reqwest_for_configuration_only"
-            },
-            {
-              "id": "signal-hook 0.3.17",
-              "target": "signal_hook"
             },
             {
               "id": "smallvec 1.11.0",
@@ -5963,17 +5697,26 @@
           }
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "gix-macros 0.1.0",
+              "target": "gix_macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.53.1"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-actor 0.25.0": {
+    "gix-actor 0.26.0": {
       "name": "gix-actor",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-actor/0.25.0/download",
-          "sha256": "8f8a773b5385e9d2f88bd879fb763ec1212585f6d630ebe13adb7bac93bce975"
+          "url": "https://crates.io/api/v1/crates/gix-actor/0.26.0/download",
+          "sha256": "8e8c6778cc03bca978b2575a03e04e5ba6f430a9dd9b0f1259f0a8a9a5e5cc66"
         }
       },
       "targets": [
@@ -6003,7 +5746,7 @@
               "target": "btoi"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
@@ -6022,17 +5765,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.25.0"
+        "version": "0.26.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-attributes 0.17.0": {
+    "gix-attributes 0.18.0": {
       "name": "gix-attributes",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-attributes/0.17.0/download",
-          "sha256": "b1ecae08f2625d8abcd27570fa2f9c2fcf01a1cd968a8d90858e63f8e08211a3"
+          "url": "https://crates.io/api/v1/crates/gix-attributes/0.18.0/download",
+          "sha256": "d3548b76829d33a7160a4685134df16de0cc3b77418302e8a9969f0b662e698f"
         }
       },
       "targets": [
@@ -6058,11 +5801,11 @@
               "target": "bstr"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -6070,12 +5813,12 @@
               "target": "gix_quote"
             },
             {
-              "id": "kstring 2.0.0",
-              "target": "kstring"
+              "id": "gix-trace 0.1.3",
+              "target": "gix_trace"
             },
             {
-              "id": "log 0.4.19",
-              "target": "log"
+              "id": "kstring 2.0.0",
+              "target": "kstring"
             },
             {
               "id": "smallvec 1.11.0",
@@ -6093,7 +5836,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.17.0"
+        "version": "0.18.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6214,13 +5957,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-commitgraph 0.19.0": {
+    "gix-commitgraph 0.20.0": {
       "name": "gix-commitgraph",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-commitgraph/0.19.0/download",
-          "sha256": "3845b3c8722a0e97d9d593c05d384bb1275a5865f1cd967523a3780ffc93168e"
+          "url": "https://crates.io/api/v1/crates/gix-commitgraph/0.20.0/download",
+          "sha256": "4676ede3a7d37e7028e2889830349a6aca22efc1d2f2dd9fa3351c1a8ddb0c6a"
         }
       },
       "targets": [
@@ -6250,11 +5993,11 @@
               "target": "gix_chunk"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
@@ -6269,17 +6012,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.19.0"
+        "version": "0.20.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-config 0.28.0": {
+    "gix-config 0.29.0": {
       "name": "gix-config",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-config/0.28.0/download",
-          "sha256": "9a312d120231dc8d5a2e34928a9a2098c1d3dbad76f0660ee38d0b1a87de5271"
+          "url": "https://crates.io/api/v1/crates/gix-config/0.29.0/download",
+          "sha256": "1108c4ac88248dd25cc8ab0d0dae796e619fb72d92f88e30e00b29d61bb93cc4"
         }
       },
       "targets": [
@@ -6305,32 +6048,28 @@
               "target": "bstr"
             },
             {
-              "id": "gix-config-value 0.13.0",
+              "id": "gix-config-value 0.14.0",
               "target": "gix_config_value"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-ref 0.35.0",
+              "id": "gix-ref 0.36.0",
               "target": "gix_ref"
             },
             {
-              "id": "gix-sec 0.9.0",
+              "id": "gix-sec 0.10.0",
               "target": "gix_sec"
-            },
-            {
-              "id": "log 0.4.19",
-              "target": "log"
             },
             {
               "id": "memchr 2.6.3",
@@ -6360,17 +6099,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.28.0"
+        "version": "0.29.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-config-value 0.13.0": {
+    "gix-config-value 0.14.0": {
       "name": "gix-config-value",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-config-value/0.13.0/download",
-          "sha256": "901e184f3d4f99bf015ca13b5ccacb09e26b400f198fe2066651089e2c490680"
+          "url": "https://crates.io/api/v1/crates/gix-config-value/0.14.0/download",
+          "sha256": "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47"
         }
       },
       "targets": [
@@ -6400,7 +6139,7 @@
               "target": "bstr"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -6418,17 +6157,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.13.0"
+        "version": "0.14.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-credentials 0.18.0": {
+    "gix-credentials 0.19.0": {
       "name": "gix-credentials",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-credentials/0.18.0/download",
-          "sha256": "2988e917f7ee4a99072354d5885ca14c9e7039de8246e96e300ab3e5060cad19"
+          "url": "https://crates.io/api/v1/crates/gix-credentials/0.19.0/download",
+          "sha256": "363e16428096b7311c380afe972831ea8b58fc1a1d1621dbdd865caf34921a54"
         }
       },
       "targets": [
@@ -6458,23 +6197,23 @@
               "target": "gix_command"
             },
             {
-              "id": "gix-config-value 0.13.0",
+              "id": "gix-config-value 0.14.0",
               "target": "gix_config_value"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-prompt 0.6.0",
+              "id": "gix-prompt 0.7.0",
               "target": "gix_prompt"
             },
             {
-              "id": "gix-sec 0.9.0",
+              "id": "gix-sec 0.10.0",
               "target": "gix_sec"
             },
             {
-              "id": "gix-url 0.22.0",
+              "id": "gix-url 0.23.0",
               "target": "gix_url"
             },
             {
@@ -6485,17 +6224,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.0"
+        "version": "0.19.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-date 0.7.4": {
+    "gix-date 0.8.0": {
       "name": "gix-date",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-date/0.7.4/download",
-          "sha256": "0a825babda995d788e30d306a49dacd1e93d5f5d33d53c7682d0347cef40333c"
+          "url": "https://crates.io/api/v1/crates/gix-date/0.8.0/download",
+          "sha256": "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d"
         }
       },
       "targets": [
@@ -6536,17 +6275,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.4"
+        "version": "0.8.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-diff 0.34.0": {
+    "gix-diff 0.35.0": {
       "name": "gix-diff",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-diff/0.34.0/download",
-          "sha256": "016be5f0789da595b61d15a862476be0cbae8fd29e2c91d66770fdd8df145773"
+          "url": "https://crates.io/api/v1/crates/gix-diff/0.35.0/download",
+          "sha256": "b45e342d148373bd9070d557e6fb1280aeae29a3e05e32506682d027278501eb"
         }
       },
       "targets": [
@@ -6565,26 +6304,15 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "blob",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
-            },
-            {
-              "id": "imara-diff 0.1.5",
-              "target": "imara_diff"
             },
             {
               "id": "thiserror 1.0.44",
@@ -6594,17 +6322,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.34.0"
+        "version": "0.35.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-discover 0.23.0": {
+    "gix-discover 0.24.0": {
       "name": "gix-discover",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-discover/0.23.0/download",
-          "sha256": "2b74760d912716b287357dae5654ad84be12a2a75a721f00b58ecdd65496e024"
+          "url": "https://crates.io/api/v1/crates/gix-discover/0.24.0/download",
+          "sha256": "da4cacda5ee9dd1b38b0e2506834e40e66c08cf050ef55c344334c76745f277b"
         }
       },
       "targets": [
@@ -6630,19 +6358,19 @@
               "target": "bstr"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-ref 0.35.0",
+              "id": "gix-ref 0.36.0",
               "target": "gix_ref"
             },
             {
-              "id": "gix-sec 0.9.0",
+              "id": "gix-sec 0.10.0",
               "target": "gix_sec"
             },
             {
@@ -6660,17 +6388,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.23.0"
+        "version": "0.24.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-features 0.33.0": {
+    "gix-features 0.34.0": {
       "name": "gix-features",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-features/0.33.0/download",
-          "sha256": "7f77decb545f63a52852578ef5f66ecd71017ffc1983d551d5fa2328d6d9817f"
+          "url": "https://crates.io/api/v1/crates/gix-features/0.34.0/download",
+          "sha256": "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
         }
       },
       "targets": [
@@ -6693,10 +6421,8 @@
           "common": [
             "crc32",
             "default",
-            "fs-walkdir-parallel",
             "io-pipe",
             "once_cell",
-            "parallel",
             "progress",
             "rustsha1",
             "walkdir",
@@ -6715,15 +6441,11 @@
               "target": "crc32fast"
             },
             {
-              "id": "crossbeam-channel 0.5.8",
-              "target": "crossbeam_channel"
-            },
-            {
               "id": "flate2 1.0.27",
               "target": "flate2"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
@@ -6731,19 +6453,11 @@
               "target": "gix_trace"
             },
             {
-              "id": "jwalk 0.8.1",
-              "target": "jwalk"
-            },
-            {
               "id": "once_cell 1.18.0",
               "target": "once_cell"
             },
             {
-              "id": "parking_lot 0.12.1",
-              "target": "parking_lot"
-            },
-            {
-              "id": "prodash 25.0.2",
+              "id": "prodash 26.2.2",
               "target": "prodash"
             },
             {
@@ -6769,17 +6483,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.33.0"
+        "version": "0.34.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-filter 0.3.0": {
+    "gix-filter 0.4.0": {
       "name": "gix-filter",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-filter/0.3.0/download",
-          "sha256": "5f5495cdd54f4c3bb05b35a525cd39df1643362d917a7e03f112564c2825feb4"
+          "url": "https://crates.io/api/v1/crates/gix-filter/0.4.0/download",
+          "sha256": "afbdb2ffae9e595d70f8c7b40953a82706d536bb8107874c258fe6368389832b"
         }
       },
       "targets": [
@@ -6809,7 +6523,7 @@
               "target": "encoding_rs"
             },
             {
-              "id": "gix-attributes 0.17.0",
+              "id": "gix-attributes 0.18.0",
               "target": "gix_attributes"
             },
             {
@@ -6817,11 +6531,11 @@
               "target": "gix_command"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
@@ -6830,7 +6544,7 @@
               "alias": "gix_packetline"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -6853,17 +6567,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.4.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-fs 0.5.0": {
+    "gix-fs 0.6.0": {
       "name": "gix-fs",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-fs/0.5.0/download",
-          "sha256": "53d5089f3338647776733a75a800a664ab046f56f21c515fa4722e395f877ef8"
+          "url": "https://crates.io/api/v1/crates/gix-fs/0.6.0/download",
+          "sha256": "404795da3d4c660c9ab6c3b2ad76d459636d1e1e4b37b0c7ff68eee898c298d4"
         }
       },
       "targets": [
@@ -6885,24 +6599,24 @@
         "deps": {
           "common": [
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.0"
+        "version": "0.6.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-glob 0.11.0": {
+    "gix-glob 0.12.0": {
       "name": "gix-glob",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-glob/0.11.0/download",
-          "sha256": "c753299d14a29ca06d7adc8464c16f1786eb97bc9a44a796ad0a37f57235a494"
+          "url": "https://crates.io/api/v1/crates/gix-glob/0.12.0/download",
+          "sha256": "e3ac79c444193b0660fe0c0925d338bd338bd643e32138784dccfb12c628b892"
         }
       },
       "targets": [
@@ -6932,28 +6646,28 @@
               "target": "bstr"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.11.0"
+        "version": "0.12.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-hash 0.12.0": {
+    "gix-hash 0.13.0": {
       "name": "gix-hash",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-hash/0.12.0/download",
-          "sha256": "7d4796bac3aaf0c2f8bea152ca924ae3bdc5f135caefe6431116bcd67e98eab9"
+          "url": "https://crates.io/api/v1/crates/gix-hash/0.13.0/download",
+          "sha256": "2ccf425543779cddaa4a7c62aba3fa9d90ea135b160be0a72dd93c063121ad4a"
         }
       },
       "targets": [
@@ -6986,17 +6700,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.12.0"
+        "version": "0.13.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-hashtable 0.3.0": {
+    "gix-hashtable 0.4.0": {
       "name": "gix-hashtable",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-hashtable/0.3.0/download",
-          "sha256": "45ad1b70efd1e77c32729d5a522f0c855e9827242feb10318e1acaf2259222c0"
+          "url": "https://crates.io/api/v1/crates/gix-hashtable/0.4.0/download",
+          "sha256": "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16"
         }
       },
       "targets": [
@@ -7018,7 +6732,7 @@
         "deps": {
           "common": [
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
@@ -7033,17 +6747,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.4.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-ignore 0.6.0": {
+    "gix-ignore 0.7.0": {
       "name": "gix-ignore",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-ignore/0.6.0/download",
-          "sha256": "b355098421f5cc91a0e5f1ef3600ae250c13b7c3c472b18c361897c6081bfbb1"
+          "url": "https://crates.io/api/v1/crates/gix-ignore/0.7.0/download",
+          "sha256": "04ff3ec0fd9fb5bb0ae36b252976b0bc94b45ba969b1639f7402425d9d6baf67"
         }
       },
       "targets": [
@@ -7069,11 +6783,11 @@
               "target": "bstr"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -7084,17 +6798,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-index 0.22.0": {
+    "gix-index 0.24.0": {
       "name": "gix-index",
-      "version": "0.22.0",
+      "version": "0.24.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-index/0.22.0/download",
-          "sha256": "a9738fc58ca30e232c7b1be8e8ab52b072979acb9bf3fa97662b5b23c0c6fbca"
+          "url": "https://crates.io/api/v1/crates/gix-index/0.24.0/download",
+          "sha256": "0e9599fc30b3d6aad231687a403f85dfa36ae37ccf1b68ee1f621ad5b7fc7a0d"
         }
       },
       "targets": [
@@ -7136,27 +6850,27 @@
               "target": "gix_bitmap"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-lock 8.0.0",
+              "id": "gix-lock 9.0.0",
               "target": "gix_lock"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-traverse 0.31.0",
+              "id": "gix-traverse 0.32.0",
               "target": "gix_traverse"
             },
             {
@@ -7179,17 +6893,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.22.0"
+        "version": "0.24.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-lock 8.0.0": {
+    "gix-lock 9.0.0": {
       "name": "gix-lock",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-lock/8.0.0/download",
-          "sha256": "de4363023577b31906b476b34eefbf76931363ec574f88b5c7b6027789f1e3ce"
+          "url": "https://crates.io/api/v1/crates/gix-lock/9.0.0/download",
+          "sha256": "1568c3d90594c60d52670f325f5db88c2d572e85c8dd45fabc23d91cadb0fd52"
         }
       },
       "targets": [
@@ -7211,7 +6925,7 @@
         "deps": {
           "common": [
             {
-              "id": "gix-tempfile 8.0.0",
+              "id": "gix-tempfile 9.0.0",
               "target": "gix_tempfile"
             },
             {
@@ -7226,23 +6940,23 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "8.0.0"
+        "version": "9.0.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-mailmap 0.17.0": {
-      "name": "gix-mailmap",
-      "version": "0.17.0",
+    "gix-macros 0.1.0": {
+      "name": "gix-macros",
+      "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-mailmap/0.17.0/download",
-          "sha256": "244a4a6f08e8104110675de649ccd20fe1d1116783063920e19aa7da197a4ad0"
+          "url": "https://crates.io/api/v1/crates/gix-macros/0.1.0/download",
+          "sha256": "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6"
         }
       },
       "targets": [
         {
-          "Library": {
-            "crate_name": "gix_mailmap",
+          "ProcMacro": {
+            "crate_name": "gix_macros",
             "crate_root": "src/lib.rs",
             "srcs": [
               "**/*.rs"
@@ -7250,7 +6964,7 @@
           }
         }
       ],
-      "library_target_name": "gix_mailmap",
+      "library_target_name": "gix_macros",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -7258,36 +6972,32 @@
         "deps": {
           "common": [
             {
-              "id": "bstr 1.6.2",
-              "target": "bstr"
+              "id": "proc-macro2 1.0.66",
+              "target": "proc_macro2"
             },
             {
-              "id": "gix-actor 0.25.0",
-              "target": "gix_actor"
+              "id": "quote 1.0.32",
+              "target": "quote"
             },
             {
-              "id": "gix-date 0.7.4",
-              "target": "gix_date"
-            },
-            {
-              "id": "thiserror 1.0.44",
-              "target": "thiserror"
+              "id": "syn 2.0.28",
+              "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.17.0"
+        "version": "0.1.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-negotiate 0.6.0": {
+    "gix-negotiate 0.7.0": {
       "name": "gix-negotiate",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-negotiate/0.6.0/download",
-          "sha256": "a0b0ea711559f843b8286cdf71ea421560c072120fae35a949bcf6b068b73745"
+          "url": "https://crates.io/api/v1/crates/gix-negotiate/0.7.0/download",
+          "sha256": "208b25af0e59d04e7313479fc949bd68e11a065b51718995139cefac498e24df"
         }
       },
       "targets": [
@@ -7313,23 +7023,23 @@
               "target": "bitflags"
             },
             {
-              "id": "gix-commitgraph 0.19.0",
+              "id": "gix-commitgraph 0.20.0",
               "target": "gix_commitgraph"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-revwalk 0.6.0",
+              "id": "gix-revwalk 0.7.0",
               "target": "gix_revwalk"
             },
             {
@@ -7344,17 +7054,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-object 0.35.0": {
+    "gix-object 0.36.0": {
       "name": "gix-object",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-object/0.35.0/download",
-          "sha256": "c4283b7b5e9438afe2e3183e9acd1c77e750800937bb56c06b750822d2ff6d95"
+          "url": "https://crates.io/api/v1/crates/gix-object/0.36.0/download",
+          "sha256": "3e5528d5b2c984044d547e696e44a8c45fa122e83cd8c2ac1da69bd474336be8"
         }
       },
       "targets": [
@@ -7384,19 +7094,19 @@
               "target": "btoi"
             },
             {
-              "id": "gix-actor 0.25.0",
+              "id": "gix-actor 0.26.0",
               "target": "gix_actor"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
@@ -7423,17 +7133,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.35.0"
+        "version": "0.36.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-odb 0.51.0": {
+    "gix-odb 0.52.0": {
       "name": "gix-odb",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-odb/0.51.0/download",
-          "sha256": "c1dd295ca055d8270de23b6037176b03782de753f75c84dabb7713f7d7e229fd"
+          "url": "https://crates.io/api/v1/crates/gix-odb/0.52.0/download",
+          "sha256": "d0446eca295459deb3d6dd6ed7d44a631479f1b7381d8087166605c7a9f717c6"
         }
       },
       "targets": [
@@ -7459,27 +7169,27 @@
               "target": "arc_swap"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-pack 0.41.0",
+              "id": "gix-pack 0.42.0",
               "target": "gix_pack"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -7502,17 +7212,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.51.0"
+        "version": "0.52.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-pack 0.41.0": {
+    "gix-pack 0.42.0": {
       "name": "gix-pack",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-pack/0.41.0/download",
-          "sha256": "e2e645c38138216b9de2f6279bfb1b8567de6f4539f8fa2761eea961d991f448"
+          "url": "https://crates.io/api/v1/crates/gix-pack/0.42.0/download",
+          "sha256": "be19ee650300d7cbac5829b637685ec44a8d921a7c2eaff8a245d8f2f008870c"
         }
       },
       "targets": [
@@ -7534,8 +7244,7 @@
         "crate_features": {
           "common": [
             "object-cache-dynamic",
-            "pack-cache-lru-dynamic",
-            "pack-cache-lru-static"
+            "streaming-input"
           ],
           "selects": {}
         },
@@ -7550,32 +7259,24 @@
               "target": "gix_chunk"
             },
             {
-              "id": "gix-diff 0.34.0",
-              "target": "gix_diff"
-            },
-            {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-hashtable 0.3.0",
+              "id": "gix-hashtable 0.4.0",
               "target": "gix_hashtable"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
-            },
-            {
-              "id": "gix-traverse 0.31.0",
-              "target": "gix_traverse"
             },
             {
               "id": "memmap2 0.7.1",
@@ -7592,23 +7293,19 @@
             {
               "id": "thiserror 1.0.44",
               "target": "thiserror"
-            },
-            {
-              "id": "uluru 3.0.0",
-              "target": "uluru"
             }
           ],
           "selects": {
             "cfg(not(target_arch = \"wasm32\"))": [
               {
-                "id": "gix-tempfile 8.0.0",
+                "id": "gix-tempfile 9.0.0",
                 "target": "gix_tempfile"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.41.0"
+        "version": "0.42.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7720,13 +7417,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-path 0.9.0": {
+    "gix-path 0.10.0": {
       "name": "gix-path",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-path/0.9.0/download",
-          "sha256": "764b31ac54472e796f08be376eaeea3e30800949650566620809659d39969dbd"
+          "url": "https://crates.io/api/v1/crates/gix-path/0.10.0/download",
+          "sha256": "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b"
         }
       },
       "targets": [
@@ -7774,17 +7471,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.9.0"
+        "version": "0.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-pathspec 0.1.0": {
+    "gix-pathspec 0.2.0": {
       "name": "gix-pathspec",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-pathspec/0.1.0/download",
-          "sha256": "b4ba6662a29a6332926494542f6144ee87a59df3c70a4c680ebd235b646d7866"
+          "url": "https://crates.io/api/v1/crates/gix-pathspec/0.2.0/download",
+          "sha256": "90a7885b4ccdc8c80740e465747bf961a8110043fdc1fda3ee80bc81885f42df"
         }
       },
       "targets": [
@@ -7814,19 +7511,19 @@
               "target": "bstr"
             },
             {
-              "id": "gix-attributes 0.17.0",
+              "id": "gix-attributes 0.18.0",
               "target": "gix_attributes"
             },
             {
-              "id": "gix-config-value 0.13.0",
+              "id": "gix-config-value 0.14.0",
               "target": "gix_config_value"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -7837,17 +7534,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.2.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-prompt 0.6.0": {
+    "gix-prompt 0.7.0": {
       "name": "gix-prompt",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-prompt/0.6.0/download",
-          "sha256": "33ebf6f126413908bfbdc27bf69f6f8b94b674457546fab8ba613be22b917d33"
+          "url": "https://crates.io/api/v1/crates/gix-prompt/0.7.0/download",
+          "sha256": "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678"
         }
       },
       "targets": [
@@ -7873,7 +7570,7 @@
               "target": "gix_command"
             },
             {
-              "id": "gix-config-value 0.13.0",
+              "id": "gix-config-value 0.14.0",
               "target": "gix_config_value"
             },
             {
@@ -7895,17 +7592,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-protocol 0.38.0": {
+    "gix-protocol 0.39.0": {
       "name": "gix-protocol",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-protocol/0.38.0/download",
-          "sha256": "9ea9a0acfb928bc0cccd6d9e4778ba367328098fe6553ab39d5763f128794bad"
+          "url": "https://crates.io/api/v1/crates/gix-protocol/0.39.0/download",
+          "sha256": "5d6ee7fc3f80140ea0651d483ecb9e680403be244849c16237fce45ac80163df"
         }
       },
       "targets": [
@@ -7941,32 +7638,32 @@
               "target": "btoi"
             },
             {
-              "id": "gix-credentials 0.18.0",
+              "id": "gix-credentials 0.19.0",
               "target": "gix_credentials"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-transport 0.35.0",
+              "id": "gix-transport 0.36.1",
               "target": "gix_transport"
-            },
-            {
-              "id": "nom 7.1.3",
-              "target": "nom"
             },
             {
               "id": "thiserror 1.0.44",
               "target": "thiserror"
+            },
+            {
+              "id": "winnow 0.5.15",
+              "target": "winnow"
             }
           ],
           "selects": {}
@@ -7981,7 +7678,7 @@
           ],
           "selects": {}
         },
-        "version": "0.38.0"
+        "version": "0.39.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8032,13 +7729,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-ref 0.35.0": {
+    "gix-ref 0.36.0": {
       "name": "gix-ref",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-ref/0.35.0/download",
-          "sha256": "993ce5c448a94038b8da1a8969c0facd6c1fbac509fa013344c580458f41527d"
+          "url": "https://crates.io/api/v1/crates/gix-ref/0.36.0/download",
+          "sha256": "3cccbfa8d5cd9b86465f27a521e0c017de54b92d9fd37c143e49c658a2f04f3a"
         }
       },
       "targets": [
@@ -8060,39 +7757,39 @@
         "deps": {
           "common": [
             {
-              "id": "gix-actor 0.25.0",
+              "id": "gix-actor 0.26.0",
               "target": "gix_actor"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-lock 8.0.0",
+              "id": "gix-lock 9.0.0",
               "target": "gix_lock"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-tempfile 8.0.0",
+              "id": "gix-tempfile 9.0.0",
               "target": "gix_tempfile"
             },
             {
@@ -8115,17 +7812,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.35.0"
+        "version": "0.36.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-refspec 0.16.0": {
+    "gix-refspec 0.17.0": {
       "name": "gix-refspec",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-refspec/0.16.0/download",
-          "sha256": "f3171923a0f9075feae790bb81d824c0c1f91a899df51508705d4957bacd006e"
+          "url": "https://crates.io/api/v1/crates/gix-refspec/0.17.0/download",
+          "sha256": "678ba30d95baa5462df9875628ed40655d5f5b8aba7028de86ed57f36e762c6c"
         }
       },
       "targets": [
@@ -8151,11 +7848,11 @@
               "target": "bstr"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-revision 0.20.0",
+              "id": "gix-revision 0.21.0",
               "target": "gix_revision"
             },
             {
@@ -8174,17 +7871,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.16.0"
+        "version": "0.17.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-revision 0.20.0": {
+    "gix-revision 0.21.0": {
       "name": "gix-revision",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-revision/0.20.0/download",
-          "sha256": "2443886b7c55e73a813f203fe8603b94ac5deb3dfad8812d25e731b81f569f27"
+          "url": "https://crates.io/api/v1/crates/gix-revision/0.21.0/download",
+          "sha256": "b3e80a5992ae446fe1745dd26523b86084e3f1b6b3e35377fe09b4f35ac8f151"
         }
       },
       "targets": [
@@ -8203,6 +7900,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "describe"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -8210,23 +7913,23 @@
               "target": "bstr"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-hashtable 0.3.0",
+              "id": "gix-hashtable 0.4.0",
               "target": "gix_hashtable"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-revwalk 0.6.0",
+              "id": "gix-revwalk 0.7.0",
               "target": "gix_revwalk"
             },
             {
@@ -8241,17 +7944,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.20.0"
+        "version": "0.21.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-revwalk 0.6.0": {
+    "gix-revwalk 0.7.0": {
       "name": "gix-revwalk",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-revwalk/0.6.0/download",
-          "sha256": "362f71e173364f67d02899388c4b3d2f6bac7c16c0f3a9bbc04683f984f59daa"
+          "url": "https://crates.io/api/v1/crates/gix-revwalk/0.7.0/download",
+          "sha256": "b806349bc1f668e09035800e07ac8045da4e39a8925a245d93142c4802224ec1"
         }
       },
       "targets": [
@@ -8273,23 +7976,23 @@
         "deps": {
           "common": [
             {
-              "id": "gix-commitgraph 0.19.0",
+              "id": "gix-commitgraph 0.20.0",
               "target": "gix_commitgraph"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-hashtable 0.3.0",
+              "id": "gix-hashtable 0.4.0",
               "target": "gix_hashtable"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
@@ -8304,17 +8007,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-sec 0.9.0": {
+    "gix-sec 0.10.0": {
       "name": "gix-sec",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-sec/0.9.0/download",
-          "sha256": "0debc2e70613a077c257c2bb45ab4f652a550ae1d00bdca356633ea9de88a230"
+          "url": "https://crates.io/api/v1/crates/gix-sec/0.10.0/download",
+          "sha256": "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28"
         }
       },
       "targets": [
@@ -8349,7 +8052,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "gix-path 0.9.0",
+                "id": "gix-path 0.10.0",
                 "target": "gix_path"
               },
               {
@@ -8360,17 +8063,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.9.0"
+        "version": "0.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-submodule 0.2.0": {
+    "gix-submodule 0.3.0": {
       "name": "gix-submodule",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-submodule/0.2.0/download",
-          "sha256": "71cc3ecd5e2387102aa275fc88fcf36e0f0b9df23a1335bf6255327abbb9bb3f"
+          "url": "https://crates.io/api/v1/crates/gix-submodule/0.3.0/download",
+          "sha256": "5ff6b99d735842a3a7fb162b660fa97acec39d576c0ca1700d9eff9344f8625d"
         }
       },
       "targets": [
@@ -8396,23 +8099,23 @@
               "target": "bstr"
             },
             {
-              "id": "gix-config 0.28.0",
+              "id": "gix-config 0.29.0",
               "target": "gix_config"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-pathspec 0.1.0",
+              "id": "gix-pathspec 0.2.0",
               "target": "gix_pathspec"
             },
             {
-              "id": "gix-refspec 0.16.0",
+              "id": "gix-refspec 0.17.0",
               "target": "gix_refspec"
             },
             {
-              "id": "gix-url 0.22.0",
+              "id": "gix-url 0.23.0",
               "target": "gix_url"
             },
             {
@@ -8423,17 +8126,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.0"
+        "version": "0.3.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-tempfile 8.0.0": {
+    "gix-tempfile 9.0.0": {
       "name": "gix-tempfile",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-tempfile/8.0.0/download",
-          "sha256": "cea558d3daf3b1d0001052b12218c66c8f84788852791333b633d7eeb6999db1"
+          "url": "https://crates.io/api/v1/crates/gix-tempfile/9.0.0/download",
+          "sha256": "2762b91ff95e27ff3ea95758c0d4efacd7435a1be3629622928b8276de0f72a8"
         }
       },
       "targets": [
@@ -8452,16 +8155,10 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "signals"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
@@ -8471,14 +8168,6 @@
             {
               "id": "parking_lot 0.12.1",
               "target": "parking_lot"
-            },
-            {
-              "id": "signal-hook 0.3.17",
-              "target": "signal_hook"
-            },
-            {
-              "id": "signal-hook-registry 1.4.1",
-              "target": "signal_hook_registry"
             },
             {
               "id": "tempfile 3.7.0",
@@ -8495,7 +8184,7 @@
           }
         },
         "edition": "2021",
-        "version": "8.0.0"
+        "version": "9.0.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8535,13 +8224,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-transport 0.35.0": {
+    "gix-transport 0.36.1": {
       "name": "gix-transport",
-      "version": "0.35.0",
+      "version": "0.36.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-transport/0.35.0/download",
-          "sha256": "3521e96c5d7d65c1d6bd632820362ac30f66391108126a4a56adb0a5cfe85d77"
+          "url": "https://crates.io/api/v1/crates/gix-transport/0.36.1/download",
+          "sha256": "95892eedefd65a6b4312aa5e166d2f740558adfb6854a2b7de73e82e54ef064c"
         }
       },
       "targets": [
@@ -8587,11 +8276,11 @@
               "target": "gix_command"
             },
             {
-              "id": "gix-credentials 0.18.0",
+              "id": "gix-credentials 0.19.0",
               "target": "gix_credentials"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
@@ -8603,11 +8292,11 @@
               "target": "gix_quote"
             },
             {
-              "id": "gix-sec 0.9.0",
+              "id": "gix-sec 0.10.0",
               "target": "gix_sec"
             },
             {
-              "id": "gix-url 0.22.0",
+              "id": "gix-url 0.23.0",
               "target": "gix_url"
             },
             {
@@ -8622,17 +8311,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.35.0"
+        "version": "0.36.1"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-traverse 0.31.0": {
+    "gix-traverse 0.32.0": {
       "name": "gix-traverse",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-traverse/0.31.0/download",
-          "sha256": "beecf2e4d8924cbe0cace0bd396f9b037fdf7db9799d5695fe70dcad959ed067"
+          "url": "https://crates.io/api/v1/crates/gix-traverse/0.32.0/download",
+          "sha256": "3ec6358f8373fb018af8fc96c9d2ec6a5b66999e2377dc40b7801351fec409ed"
         }
       },
       "targets": [
@@ -8654,27 +8343,27 @@
         "deps": {
           "common": [
             {
-              "id": "gix-commitgraph 0.19.0",
+              "id": "gix-commitgraph 0.20.0",
               "target": "gix_commitgraph"
             },
             {
-              "id": "gix-date 0.7.4",
+              "id": "gix-date 0.8.0",
               "target": "gix_date"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-hashtable 0.3.0",
+              "id": "gix-hashtable 0.4.0",
               "target": "gix_hashtable"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-revwalk 0.6.0",
+              "id": "gix-revwalk 0.7.0",
               "target": "gix_revwalk"
             },
             {
@@ -8689,17 +8378,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.31.0"
+        "version": "0.32.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-url 0.22.0": {
+    "gix-url 0.23.0": {
       "name": "gix-url",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-url/0.22.0/download",
-          "sha256": "6059e15828df32027a7db9097e5a9baf320d2dcc10a4e1598ffe05be8dfd1fa6"
+          "url": "https://crates.io/api/v1/crates/gix-url/0.23.0/download",
+          "sha256": "1c79d595b99a6c7ab274f3c991735a0c0f5a816a3da460f513c48edf1c7bf2cc"
         }
       },
       "targets": [
@@ -8725,11 +8414,11 @@
               "target": "bstr"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
@@ -8748,7 +8437,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.22.0"
+        "version": "0.23.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8834,13 +8523,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-worktree 0.24.0": {
+    "gix-worktree 0.25.0": {
       "name": "gix-worktree",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-worktree/0.24.0/download",
-          "sha256": "a38eab0fdd752ecfa50130c127c9f42bd329bf7f4e52872f4ac24c12bbc02baf"
+          "url": "https://crates.io/api/v1/crates/gix-worktree/0.25.0/download",
+          "sha256": "addabd470ca4ce3ab893e32a5743971a530b8fc0eee5c23844849abf3c9ea6d6"
         }
       },
       "targets": [
@@ -8859,6 +8548,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "attributes"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -8866,56 +8561,56 @@
               "target": "bstr"
             },
             {
-              "id": "gix-attributes 0.17.0",
+              "id": "gix-attributes 0.18.0",
               "target": "gix_attributes"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-ignore 0.6.0",
+              "id": "gix-ignore 0.7.0",
               "target": "gix_ignore"
             },
             {
-              "id": "gix-index 0.22.0",
+              "id": "gix-index 0.24.0",
               "target": "gix_index"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.24.0"
+        "version": "0.25.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gix-worktree-state 0.1.0": {
+    "gix-worktree-state 0.2.0": {
       "name": "gix-worktree-state",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gix-worktree-state/0.1.0/download",
-          "sha256": "44629a04d238493f0da657a0eee4d60086f0172c364ca4a71398b1898fda32a6"
+          "url": "https://crates.io/api/v1/crates/gix-worktree-state/0.2.0/download",
+          "sha256": "02daf5a1d381280e3c5803a3745ee2abf09d2873118136aaadc0ed96ed438aeb"
         }
       },
       "targets": [
@@ -8941,39 +8636,39 @@
               "target": "bstr"
             },
             {
-              "id": "gix-features 0.33.0",
+              "id": "gix-features 0.34.0",
               "target": "gix_features"
             },
             {
-              "id": "gix-filter 0.3.0",
+              "id": "gix-filter 0.4.0",
               "target": "gix_filter"
             },
             {
-              "id": "gix-fs 0.5.0",
+              "id": "gix-fs 0.6.0",
               "target": "gix_fs"
             },
             {
-              "id": "gix-glob 0.11.0",
+              "id": "gix-glob 0.12.0",
               "target": "gix_glob"
             },
             {
-              "id": "gix-hash 0.12.0",
+              "id": "gix-hash 0.13.0",
               "target": "gix_hash"
             },
             {
-              "id": "gix-index 0.22.0",
+              "id": "gix-index 0.24.0",
               "target": "gix_index"
             },
             {
-              "id": "gix-object 0.35.0",
+              "id": "gix-object 0.36.0",
               "target": "gix_object"
             },
             {
-              "id": "gix-path 0.9.0",
+              "id": "gix-path 0.10.0",
               "target": "gix_path"
             },
             {
-              "id": "gix-worktree 0.24.0",
+              "id": "gix-worktree 0.25.0",
               "target": "gix_worktree"
             },
             {
@@ -8988,7 +8683,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.0"
+        "version": "0.2.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -9128,7 +8823,6 @@
         ],
         "crate_features": {
           "common": [
-            "inline-more",
             "raw"
           ],
           "selects": {}
@@ -9887,56 +9581,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "imara-diff 0.1.5": {
-      "name": "imara-diff",
-      "version": "0.1.5",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/imara-diff/0.1.5/download",
-          "sha256": "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "imara_diff",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "imara_diff",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "unified_diff"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ahash 0.8.3",
-              "target": "ahash"
-            },
-            {
-              "id": "hashbrown 0.12.3",
-              "target": "hashbrown"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.5"
-      },
-      "license": "Apache-2.0"
-    },
     "indenter 0.3.3": {
       "name": "indenter",
       "version": "0.3.3",
@@ -10488,49 +10132,6 @@
         "version": "0.3.64"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "jwalk 0.8.1": {
-      "name": "jwalk",
-      "version": "0.8.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/jwalk/0.8.1/download",
-          "sha256": "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "jwalk",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "jwalk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "crossbeam 0.8.2",
-              "target": "crossbeam"
-            },
-            {
-              "id": "rayon 1.7.0",
-              "target": "rayon"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.1"
-      },
-      "license": "MIT"
     },
     "kstring 2.0.0": {
       "name": "kstring",
@@ -11411,42 +11012,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "minimal-lexical 0.2.1": {
-      "name": "minimal-lexical",
-      "version": "0.2.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/minimal-lexical/0.2.1/download",
-          "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "minimal_lexical",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "minimal_lexical",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "miniz_oxide 0.6.2": {
       "name": "miniz_oxide",
       "version": "0.6.2",
@@ -11663,56 +11228,6 @@
         "version": "0.1.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "nom 7.1.3": {
-      "name": "nom",
-      "version": "7.1.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/nom/7.1.3/download",
-          "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "nom",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "nom",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "memchr 2.6.3",
-              "target": "memchr"
-            },
-            {
-              "id": "minimal-lexical 0.2.1",
-              "target": "minimal_lexical"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "7.1.3"
-      },
-      "license": "MIT"
     },
     "nu-ansi-term 0.46.0": {
       "name": "nu-ansi-term",
@@ -12038,95 +11553,7 @@
             "race",
             "std"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "unstable"
-            ],
-            "aarch64-apple-ios": [
-              "unstable"
-            ],
-            "aarch64-apple-ios-sim": [
-              "unstable"
-            ],
-            "aarch64-fuchsia": [
-              "unstable"
-            ],
-            "aarch64-linux-android": [
-              "unstable"
-            ],
-            "aarch64-pc-windows-msvc": [
-              "unstable"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "unstable"
-            ],
-            "arm-unknown-linux-gnueabi": [
-              "unstable"
-            ],
-            "armv7-linux-androideabi": [
-              "unstable"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "unstable"
-            ],
-            "i686-apple-darwin": [
-              "unstable"
-            ],
-            "i686-linux-android": [
-              "unstable"
-            ],
-            "i686-pc-windows-msvc": [
-              "unstable"
-            ],
-            "i686-unknown-freebsd": [
-              "unstable"
-            ],
-            "i686-unknown-linux-gnu": [
-              "unstable"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "unstable"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "unstable"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "unstable"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "unstable"
-            ],
-            "wasm32-unknown-unknown": [
-              "unstable"
-            ],
-            "wasm32-wasi": [
-              "unstable"
-            ],
-            "x86_64-apple-darwin": [
-              "unstable"
-            ],
-            "x86_64-apple-ios": [
-              "unstable"
-            ],
-            "x86_64-fuchsia": [
-              "unstable"
-            ],
-            "x86_64-linux-android": [
-              "unstable"
-            ],
-            "x86_64-pc-windows-msvc": [
-              "unstable"
-            ],
-            "x86_64-unknown-freebsd": [
-              "unstable"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "unstable"
-            ],
-            "x86_64-unknown-none": [
-              "unstable"
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "1.18.0"
@@ -13357,13 +12784,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "prodash 25.0.2": {
+    "prodash 26.2.2": {
       "name": "prodash",
-      "version": "25.0.2",
+      "version": "26.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/prodash/25.0.2/download",
-          "sha256": "1d67eb4220992a4a052a4bb03cf776e493ecb1a3a36bab551804153d63486af7"
+          "url": "https://crates.io/api/v1/crates/prodash/26.2.2/download",
+          "sha256": "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf"
         }
       },
       "targets": [
@@ -13383,7 +12810,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "25.0.2"
+        "version": "26.2.2"
       },
       "license": "MIT"
     },
@@ -15665,13 +15092,13 @@
       },
       "license": "ISC"
     },
-    "rustsec 0.28.1": {
+    "rustsec 0.28.2": {
       "name": "rustsec",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustsec/0.28.1/download",
-          "sha256": "83d7720432fa13011a007fe2cc682175ce5edab470dce72f0ecca76cb4fa5ba6"
+          "url": "https://crates.io/api/v1/crates/rustsec/0.28.2/download",
+          "sha256": "4f099fa0229b64392c5072719467f17f3f4e40c4e1baf9d45986692a6101c51a"
         }
       },
       "targets": [
@@ -15713,6 +15140,10 @@
               "target": "fs_err"
             },
             {
+              "id": "gix 0.53.1",
+              "target": "gix"
+            },
+            {
               "id": "home 0.5.5",
               "target": "home"
             },
@@ -15729,7 +15160,7 @@
               "target": "serde"
             },
             {
-              "id": "tame-index 0.5.5",
+              "id": "tame-index 0.6.0",
               "target": "tame_index"
             },
             {
@@ -15752,7 +15183,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.28.1"
+        "version": "0.28.2"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -16588,67 +16019,6 @@
       },
       "license": "MIT"
     },
-    "signal-hook 0.3.17": {
-      "name": "signal-hook",
-      "version": "0.3.17",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/signal-hook/0.3.17/download",
-          "sha256": "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "signal_hook",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "signal_hook",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.147",
-              "target": "libc"
-            },
-            {
-              "id": "signal-hook 0.3.17",
-              "target": "build_script_build"
-            },
-            {
-              "id": "signal-hook-registry 1.4.1",
-              "target": "signal_hook_registry"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.17"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0/MIT"
-    },
     "signal-hook-registry 1.4.1": {
       "name": "signal-hook-registry",
       "version": "1.4.1",
@@ -17155,6 +16525,7 @@
             "default",
             "derive",
             "extra-traits",
+            "fold",
             "full",
             "parsing",
             "printing",
@@ -17281,13 +16652,13 @@
       },
       "license": "MIT"
     },
-    "tame-index 0.5.5": {
+    "tame-index 0.6.0": {
       "name": "tame-index",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tame-index/0.5.5/download",
-          "sha256": "239b73acdc37c857aae3832bdc739b937b038e5e8b148191a79545a2beb5af74"
+          "url": "https://crates.io/api/v1/crates/tame-index/0.6.0/download",
+          "sha256": "e6b3fea0e225ef36939de3613334dbbc02da041c1830e4a84260b0137b3bc0c7"
         }
       },
       "targets": [
@@ -17325,7 +16696,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "gix 0.52.0",
+              "id": "gix 0.53.1",
               "target": "gix"
             },
             {
@@ -17384,7 +16755,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.5"
+        "version": "0.6.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -20224,45 +19595,6 @@
       },
       "license": "MIT"
     },
-    "uluru 3.0.0": {
-      "name": "uluru",
-      "version": "3.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/uluru/3.0.0/download",
-          "sha256": "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "uluru",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "uluru",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "arrayvec 0.7.4",
-              "target": "arrayvec"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "3.0.0"
-      },
-      "license": "MPL-2.0"
-    },
     "unicode-bidi 0.3.13": {
       "name": "unicode-bidi",
       "version": "0.3.13",
@@ -22954,7 +22286,7 @@
     }
   },
   "binary_crates": [
-    "cargo-audit 0.18.1",
+    "cargo-audit 0.18.2",
     "protoc-gen-prost 0.2.3",
     "protoc-gen-tonic 0.3.0",
     "tree-sitter-cli 0.20.8"
@@ -23155,37 +22487,6 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
-    ],
-    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "wasm32-unknown-unknown",
-      "wasm32-wasi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-none"
     ],
     "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
       "aarch64-apple-darwin",

--- a/build/deps/crates/Cargo.lock
+++ b/build/deps/crates/Cargo.lock
@@ -57,18 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +143,6 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ascii"
@@ -395,9 +377,9 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98bf8e948b35c7e5c715db6a7e82c7eccb8ec722965287b59f3ac15431288f9b"
+checksum = "596642f33fd57a8014990a19a449473184938642d8011b6e27a5ad50195c5e09"
 dependencies = [
  "abscissa_core",
  "auditable-info",
@@ -611,20 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,16 +624,6 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1027,9 +985,9 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gix"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35ed1401a11506b45361746507a7c94c546574ddd7dfc2717f8941e30070254"
+checksum = "06a8c9f9452078f474fecd2880de84819b8c77224ab62273275b646bf785f906"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -1048,7 +1006,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-lock",
- "gix-mailmap",
+ "gix-macros",
  "gix-negotiate",
  "gix-object",
  "gix-odb",
@@ -1060,6 +1018,7 @@ dependencies = [
  "gix-ref",
  "gix-refspec",
  "gix-revision",
+ "gix-revwalk",
  "gix-sec",
  "gix-submodule",
  "gix-tempfile",
@@ -1071,11 +1030,8 @@ dependencies = [
  "gix-validate",
  "gix-worktree",
  "gix-worktree-state",
- "log",
  "once_cell",
  "parking_lot",
- "reqwest",
- "signal-hook",
  "smallvec",
  "thiserror",
  "unicode-normalization",
@@ -1083,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8a773b5385e9d2f88bd879fb763ec1212585f6d630ebe13adb7bac93bce975"
+checksum = "8e8c6778cc03bca978b2575a03e04e5ba6f430a9dd9b0f1259f0a8a9a5e5cc66"
 dependencies = [
  "bstr",
  "btoi",
@@ -1097,16 +1053,16 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ecae08f2625d8abcd27570fa2f9c2fcf01a1cd968a8d90858e63f8e08211a3"
+checksum = "d3548b76829d33a7160a4685134df16de0cc3b77418302e8a9969f0b662e698f"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path",
  "gix-quote",
+ "gix-trace",
  "kstring",
- "log",
  "smallvec",
  "thiserror",
  "unicode-bom",
@@ -1141,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3845b3c8722a0e97d9d593c05d384bb1275a5865f1cd967523a3780ffc93168e"
+checksum = "4676ede3a7d37e7028e2889830349a6aca22efc1d2f2dd9fa3351c1a8ddb0c6a"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -1155,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a312d120231dc8d5a2e34928a9a2098c1d3dbad76f0660ee38d0b1a87de5271"
+checksum = "1108c4ac88248dd25cc8ab0d0dae796e619fb72d92f88e30e00b29d61bb93cc4"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1166,7 +1122,6 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "log",
  "memchr",
  "once_cell",
  "smallvec",
@@ -1177,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901e184f3d4f99bf015ca13b5ccacb09e26b400f198fe2066651089e2c490680"
+checksum = "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1190,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2988e917f7ee4a99072354d5885ca14c9e7039de8246e96e300ab3e5060cad19"
+checksum = "363e16428096b7311c380afe972831ea8b58fc1a1d1621dbdd865caf34921a54"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1206,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a825babda995d788e30d306a49dacd1e93d5f5d33d53c7682d0347cef40333c"
+checksum = "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d"
 dependencies = [
  "bstr",
  "itoa",
@@ -1218,21 +1173,20 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016be5f0789da595b61d15a862476be0cbae8fd29e2c91d66770fdd8df145773"
+checksum = "b45e342d148373bd9070d557e6fb1280aeae29a3e05e32506682d027278501eb"
 dependencies = [
  "gix-hash",
  "gix-object",
- "imara-diff",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b74760d912716b287357dae5654ad84be12a2a75a721f00b58ecdd65496e024"
+checksum = "da4cacda5ee9dd1b38b0e2506834e40e66c08cf050ef55c344334c76745f277b"
 dependencies = [
  "bstr",
  "dunce",
@@ -1245,20 +1199,17 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f77decb545f63a52852578ef5f66ecd71017ffc1983d551d5fa2328d6d9817f"
+checksum = "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
 dependencies = [
  "bytes",
  "crc32fast",
- "crossbeam-channel",
  "flate2",
  "gix-hash",
  "gix-trace",
- "jwalk",
  "libc",
  "once_cell",
- "parking_lot",
  "prodash",
  "sha1_smol",
  "thiserror",
@@ -1267,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5495cdd54f4c3bb05b35a525cd39df1643362d917a7e03f112564c2825feb4"
+checksum = "afbdb2ffae9e595d70f8c7b40953a82706d536bb8107874c258fe6368389832b"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1287,18 +1238,18 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d5089f3338647776733a75a800a664ab046f56f21c515fa4722e395f877ef8"
+checksum = "404795da3d4c660c9ab6c3b2ad76d459636d1e1e4b37b0c7ff68eee898c298d4"
 dependencies = [
  "gix-features",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c753299d14a29ca06d7adc8464c16f1786eb97bc9a44a796ad0a37f57235a494"
+checksum = "e3ac79c444193b0660fe0c0925d338bd338bd643e32138784dccfb12c628b892"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1308,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4796bac3aaf0c2f8bea152ca924ae3bdc5f135caefe6431116bcd67e98eab9"
+checksum = "2ccf425543779cddaa4a7c62aba3fa9d90ea135b160be0a72dd93c063121ad4a"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -1318,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ad1b70efd1e77c32729d5a522f0c855e9827242feb10318e1acaf2259222c0"
+checksum = "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.0",
@@ -1329,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b355098421f5cc91a0e5f1ef3600ae250c13b7c3c472b18c361897c6081bfbb1"
+checksum = "04ff3ec0fd9fb5bb0ae36b252976b0bc94b45ba969b1639f7402425d9d6baf67"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1341,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9738fc58ca30e232c7b1be8e8ab52b072979acb9bf3fa97662b5b23c0c6fbca"
+checksum = "0e9599fc30b3d6aad231687a403f85dfa36ae37ccf1b68ee1f621ad5b7fc7a0d"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1364,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4363023577b31906b476b34eefbf76931363ec574f88b5c7b6027789f1e3ce"
+checksum = "1568c3d90594c60d52670f325f5db88c2d572e85c8dd45fabc23d91cadb0fd52"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1374,22 +1325,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-mailmap"
-version = "0.17.0"
+name = "gix-macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244a4a6f08e8104110675de649ccd20fe1d1116783063920e19aa7da197a4ad0"
+checksum = "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6"
 dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "thiserror",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b0ea711559f843b8286cdf71ea421560c072120fae35a949bcf6b068b73745"
+checksum = "208b25af0e59d04e7313479fc949bd68e11a065b51718995139cefac498e24df"
 dependencies = [
  "bitflags 2.3.3",
  "gix-commitgraph",
@@ -1403,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4283b7b5e9438afe2e3183e9acd1c77e750800937bb56c06b750822d2ff6d95"
+checksum = "3e5528d5b2c984044d547e696e44a8c45fa122e83cd8c2ac1da69bd474336be8"
 dependencies = [
  "bstr",
  "btoi",
@@ -1422,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dd295ca055d8270de23b6037176b03782de753f75c84dabb7713f7d7e229fd"
+checksum = "d0446eca295459deb3d6dd6ed7d44a631479f1b7381d8087166605c7a9f717c6"
 dependencies = [
  "arc-swap",
  "gix-date",
@@ -1441,25 +1391,22 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e645c38138216b9de2f6279bfb1b8567de6f4539f8fa2761eea961d991f448"
+checksum = "be19ee650300d7cbac5829b637685ec44a8d921a7c2eaff8a245d8f2f008870c"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-diff",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-path",
  "gix-tempfile",
- "gix-traverse",
  "memmap2",
  "parking_lot",
  "smallvec",
  "thiserror",
- "uluru",
 ]
 
 [[package]]
@@ -1486,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764b31ac54472e796f08be376eaeea3e30800949650566620809659d39969dbd"
+checksum = "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1499,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ba6662a29a6332926494542f6144ee87a59df3c70a4c680ebd235b646d7866"
+checksum = "90a7885b4ccdc8c80740e465747bf961a8110043fdc1fda3ee80bc81885f42df"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1514,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ebf6f126413908bfbdc27bf69f6f8b94b674457546fab8ba613be22b917d33"
+checksum = "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -1527,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea9a0acfb928bc0cccd6d9e4778ba367328098fe6553ab39d5763f128794bad"
+checksum = "5d6ee7fc3f80140ea0651d483ecb9e680403be244849c16237fce45ac80163df"
 dependencies = [
  "bstr",
  "btoi",
@@ -1539,8 +1486,8 @@ dependencies = [
  "gix-hash",
  "gix-transport",
  "maybe-async",
- "nom",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -1556,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993ce5c448a94038b8da1a8969c0facd6c1fbac509fa013344c580458f41527d"
+checksum = "3cccbfa8d5cd9b86465f27a521e0c017de54b92d9fd37c143e49c658a2f04f3a"
 dependencies = [
  "gix-actor",
  "gix-date",
@@ -1577,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3171923a0f9075feae790bb81d824c0c1f91a899df51508705d4957bacd006e"
+checksum = "678ba30d95baa5462df9875628ed40655d5f5b8aba7028de86ed57f36e762c6c"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -1591,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2443886b7c55e73a813f203fe8603b94ac5deb3dfad8812d25e731b81f569f27"
+checksum = "b3e80a5992ae446fe1745dd26523b86084e3f1b6b3e35377fe09b4f35ac8f151"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1607,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f71e173364f67d02899388c4b3d2f6bac7c16c0f3a9bbc04683f984f59daa"
+checksum = "b806349bc1f668e09035800e07ac8045da4e39a8925a245d93142c4802224ec1"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1622,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debc2e70613a077c257c2bb45ab4f652a550ae1d00bdca356633ea9de88a230"
+checksum = "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28"
 dependencies = [
  "bitflags 2.3.3",
  "gix-path",
@@ -1634,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cc3ecd5e2387102aa275fc88fcf36e0f0b9df23a1335bf6255327abbb9bb3f"
+checksum = "5ff6b99d735842a3a7fb162b660fa97acec39d576c0ca1700d9eff9344f8625d"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1649,16 +1596,14 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea558d3daf3b1d0001052b12218c66c8f84788852791333b633d7eeb6999db1"
+checksum = "2762b91ff95e27ff3ea95758c0d4efacd7435a1be3629622928b8276de0f72a8"
 dependencies = [
  "gix-fs",
  "libc",
  "once_cell",
  "parking_lot",
- "signal-hook",
- "signal-hook-registry",
  "tempfile",
 ]
 
@@ -1670,9 +1615,9 @@ checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
 
 [[package]]
 name = "gix-transport"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3521e96c5d7d65c1d6bd632820362ac30f66391108126a4a56adb0a5cfe85d77"
+checksum = "95892eedefd65a6b4312aa5e166d2f740558adfb6854a2b7de73e82e54ef064c"
 dependencies = [
  "base64",
  "bstr",
@@ -1689,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beecf2e4d8924cbe0cace0bd396f9b037fdf7db9799d5695fe70dcad959ed067"
+checksum = "3ec6358f8373fb018af8fc96c9d2ec6a5b66999e2377dc40b7801351fec409ed"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1705,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6059e15828df32027a7db9097e5a9baf320d2dcc10a4e1598ffe05be8dfd1fa6"
+checksum = "1c79d595b99a6c7ab274f3c991735a0c0f5a816a3da460f513c48edf1c7bf2cc"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1738,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38eab0fdd752ecfa50130c127c9f42bd329bf7f4e52872f4ac24c12bbc02baf"
+checksum = "addabd470ca4ce3ab893e32a5743971a530b8fc0eee5c23844849abf3c9ea6d6"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1756,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44629a04d238493f0da657a0eee4d60086f0172c364ca4a71398b1898fda32a6"
+checksum = "02daf5a1d381280e3c5803a3745ee2abf09d2873118136aaadc0ed96ed438aeb"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1957,16 +1902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imara-diff"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
-dependencies = [
- "ahash",
- "hashbrown 0.12.3",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,16 +2007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
 ]
 
 [[package]]
@@ -2226,12 +2151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,16 +2190,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2553,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "25.0.2"
+version = "26.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d67eb4220992a4a052a4bb03cf776e493ecb1a3a36bab551804153d63486af7"
+checksum = "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf"
 
 [[package]]
 name = "prost"
@@ -2983,13 +2892,14 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d7720432fa13011a007fe2cc682175ce5edab470dce72f0ecca76cb4fa5ba6"
+checksum = "4f099fa0229b64392c5072719467f17f3f4e40c4e1baf9d45986692a6101c51a"
 dependencies = [
  "cargo-lock",
  "cvss",
  "fs-err",
+ "gix",
  "home",
  "platforms",
  "semver",
@@ -3158,16 +3068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239b73acdc37c857aae3832bdc739b937b038e5e8b148191a79545a2beb5af74"
+checksum = "e6b3fea0e225ef36939de3613334dbbc02da041c1830e4a84260b0137b3bc0c7"
 dependencies = [
  "camino",
  "crossbeam-channel",
@@ -3848,15 +3748,6 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
-]
-
-[[package]]
-name = "uluru"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]

--- a/build/deps/crates/defs.bzl
+++ b/build/deps/crates/defs.bzl
@@ -241,7 +241,7 @@ _crates = {
     # For auditing Rust packages.
     "cargo-audit": struct(
         spec = crate.spec(
-            version = "0.18.1",
+            version = "0.18.2",
         ),
         annotations = [crate.annotation(
             gen_binaries = ["cargo-audit"],


### PR DESCRIPTION
Bumped rustsec to 0.28.2 in cargo-audit to fix RUSTSEC-2023-0064.

https://rustsec.org/advisories/RUSTSEC-2023-0064.html
