### PR TITLE
tools/buildifier: setup buildifier_test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,11 +30,18 @@ common --experimental_allow_tags_propagation
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
+# Disables a legacy feature where local sandboxed execution can silently fall back to non-sandboxed
+# if an action can't be run in a sandbox. This will be the default flag in a future release (probably 7.0).
+#
+# https://github.com/bazelbuild/bazel/issues/16522
+build --noincompatible_legacy_local_fallback
+
 # The option sandboxed causes commands to be executed inside a sandbox on the local machine.
 # This requires that all input files, data dependencies and tools are listed as direct dependencies in the srcs, data and tools attributes.
 # Bazel enables local sandboxing by default, on systems that support sandboxed execution.
+#
 # https://bazel.build/docs/user-manual#spawn-strategy
-build --spawn_strategy=sandboxed
+build --spawn_strategy=sandboxed,local
 
 # Restricts network access by default for actions.
 # https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -28,9 +28,6 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
-      - name: Buildifier
-        run: $BAZEL run $BAZEL_ARGS //tools/buildifier
-
       - name: Build
         run: $BAZEL build $BAZEL_ARGS //...
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 exports_files([
     ".clippy.toml",
     ".rustfmt.toml",
+    "WORKSPACE",
 ])
 
 jq(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,9 +126,9 @@ http_archive(
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "b7187e0856280feb0658ab9d629c244e638022819ded8243fb02e0c1d4db8f1c",
-    strip_prefix = "buildtools-6.3.2",
-    urls = ["https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.3.2.tar.gz"],
+    sha256 = "42968f9134ba2c75c03bb271bd7bb062afb7da449f9b913c96e5be4ce890030a",
+    strip_prefix = "buildtools-6.3.3",
+    urls = ["https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.3.3.tar.gz"],
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")

--- a/build/deps/setup.bzl
+++ b/build/deps/setup.bzl
@@ -1,6 +1,7 @@
 load("@bin_crates//:defs.bzl", bin_crates_repositories = "crate_repositories")
 load("@crates//:defs.bzl", crates_repositories = "crate_repositories")
 
+# buildifier: disable=unnamed-macro
 def build_dependencies_setup():
     bin_crates_repositories()
     crates_repositories()

--- a/fuzzing/BUILD.bazel
+++ b/fuzzing/BUILD.bazel
@@ -2,10 +2,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 rust_binary(
     name = "fuzz",
-    srcs = glob([
-        "main.rs",
-        "cmd/*.rs",
-    ]),
+    srcs = ["main.rs"] + glob(["cmd/*.rs"]),
     visibility = ["//visibility:public"],
     deps = [
         "//process",

--- a/fuzzing/examples/BUILD.bazel
+++ b/fuzzing/examples/BUILD.bazel
@@ -1,13 +1,5 @@
 load("//fuzzing:defs.bzl", "rust_fuzz_test")
 
-filegroup(
-    name = "corpus_filegroup",
-    srcs = glob([
-        "corpus/corpus_0",
-        "corpus/**",
-    ]),
-)
-
 rust_fuzz_test(
     name = "should_not_fail",
     srcs = ["should_not_fail.rs"],

--- a/tools/buildifier/BUILD.bazel
+++ b/tools/buildifier/BUILD.bazel
@@ -10,7 +10,6 @@ _exclude_patterns = [
 ]
 
 _lint_warnings = [
-    "+out-of-order-load",
     "-function-docstring",
     "-function-docstring-args",
     "-module-docstring",

--- a/tools/buildifier/BUILD.bazel
+++ b/tools/buildifier/BUILD.bazel
@@ -1,33 +1,37 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
 alias(
     name = "buildifier",
     actual = ":fix",
 )
 
-_EXCLUDE_PATTERNS = [
+_exclude_patterns = [
     "./tmp/**/*",
+]
+
+_lint_warnings = [
+    "+out-of-order-load",
+    "-function-docstring",
+    "-function-docstring-args",
+    "-module-docstring",
+    "-unnamed-macro",
 ]
 
 buildifier(
     name = "fix",
-    exclude_patterns = _EXCLUDE_PATTERNS,
+    exclude_patterns = _exclude_patterns,
     lint_mode = "fix",
-    lint_warnings = [
-        "+out-of-order-load",
-    ],
+    lint_warnings = _lint_warnings,
 )
 
-# `mode = "check"` is deprecated.
-# https://github.com/bazelbuild/buildtools/issues/1005
-buildifier(
+buildifier_test(
     name = "check",
-    exclude_patterns = _EXCLUDE_PATTERNS,
+    size = "small",
+    timeout = "short",
+    exclude_patterns = _exclude_patterns,
     lint_mode = "warn",
-    lint_warnings = [
-        "+out-of-order-load",
-        "-function-docstring",
-        "-module-docstring",
-    ],
-    mode = "check",
+    lint_warnings = _lint_warnings,
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:WORKSPACE",
 )

--- a/tools/buildifier/BUILD.bazel
+++ b/tools/buildifier/BUILD.bazel
@@ -13,7 +13,6 @@ _lint_warnings = [
     "-function-docstring",
     "-function-docstring-args",
     "-module-docstring",
-    "-unnamed-macro",
 ]
 
 buildifier(


### PR DESCRIPTION
Changed to use buildifier_test to suppress a deprecation warnings.

This action escapes the sandbox and operates on all files
without having to supply srcs.
Also, some configs have been modified to accommodate this change.
