### PR TITLE
process/entrypoint: setup container_structure_test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,6 +115,10 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
@@ -128,6 +132,10 @@ oci_register_toolchains(
     # Note that it does not support docker-format images.
     # zot_version = LATEST_ZOT_VERSION,
 )
+
+load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
+
+container_structure_test_register_toolchain(name = "cst")
 
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 

--- a/process/entrypoint/BUILD
+++ b/process/entrypoint/BUILD
@@ -1,3 +1,6 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc_test", "rust_library", "rust_test")
 
 rust_library(
@@ -37,16 +40,6 @@ rust_doc_test(
     crate = ":entrypoint",
 )
 
-cc_binary(
-    name = "orphan",
-    srcs = ["orphan.c"],
-)
-
-cc_binary(
-    name = "zombie",
-    srcs = ["zombie.c"],
-)
-
 rust_binary(
     name = "coordinator",
     srcs = ["bin/coordinator.rs"],
@@ -60,4 +53,52 @@ rust_binary(
         "@crates//:tracing",
         "@crates//:tracing-subscriber",
     ],
+)
+
+pkg_tar(
+    name = "coordinator_pkg",
+    srcs = [":coordinator"],
+)
+
+cc_binary(
+    name = "orphan",
+    srcs = ["orphan.c"],
+)
+
+cc_binary(
+    name = "zombie",
+    srcs = ["zombie.c"],
+)
+
+pkg_tar(
+    name = "orphan_pkg",
+    srcs = [":orphan"],
+)
+
+pkg_tar(
+    name = "zombie_pkg",
+    srcs = [":zombie"],
+)
+
+oci_image(
+    name = "coordinator_test_image",
+    base = "@distroless_cc_nonroot",
+    entrypoint = ["/coordinator"],
+    tars = [
+        ":coordinator_pkg",
+        ":orphan_pkg",
+        ":zombie_pkg",
+    ],
+)
+
+oci_tarball(
+    name = "coordinator_test_tarball",
+    image = ":coordinator_test_image",
+    repo_tags = [package_name() + ":coordinator_test_tarball"],
+)
+
+container_structure_test(
+    name = "coordinator_test",
+    configs = ["testdata/coordinator_test.yaml"],
+    image = ":coordinator_test_image",
 )

--- a/process/entrypoint/BUILD
+++ b/process/entrypoint/BUILD
@@ -101,4 +101,7 @@ container_structure_test(
     name = "coordinator_test",
     configs = ["testdata/coordinator_test.yaml"],
     image = ":coordinator_test_image",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )

--- a/process/entrypoint/testdata/coordinator_test.yaml
+++ b/process/entrypoint/testdata/coordinator_test.yaml
@@ -1,0 +1,6 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: 'Root'
+    path: '/'
+    shouldExist: true

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -31,17 +31,17 @@ _http_archives = {
             "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
         ],
     },
+    "aspect_bazel_lib": {
+        "sha256": "09b51a9957adc56c905a2c980d6eb06f04beb1d85c665b467f659871403cf423",
+        "strip_prefix": "bazel-lib-1.34.5",
+        "url": "https://github.com/aspect-build/bazel-lib/releases/download/v1.34.5/bazel-lib-v1.34.5.tar.gz",
+    },
     "bazel_skylib": {
         "sha256": "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
         ],
-    },
-    "aspect_bazel_lib": {
-        "sha256": "09b51a9957adc56c905a2c980d6eb06f04beb1d85c665b467f659871403cf423",
-        "strip_prefix": "bazel-lib-1.34.5",
-        "url": "https://github.com/aspect-build/bazel-lib/releases/download/v1.34.5/bazel-lib-v1.34.5.tar.gz",
     },
     "rules_cc": {
         "sha256": "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
@@ -123,12 +123,22 @@ _http_archives = {
         "strip_prefix": "buildtools-6.3.3",
         "urls": ["https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.3.3.tar.gz"],
     },
-
-    # OCI
+    "rules_pkg": {
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+        ],
+        "sha256": "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    },
     "rules_oci": {
         "sha256": "a3b6f4c0051938940ccf251a7bdcdf7ac5a93ae00e63ad107c9c6d3bfe20885b",
         "strip_prefix": "rules_oci-1.3.1",
         "url": "https://github.com/bazel-contrib/rules_oci/releases/download/v1.3.1/rules_oci-v1.3.1.tar.gz",
+    },
+    "container_structure_test": {
+        "sha256": "2da13da4c4fec9d4627d4084b122be0f4d118bd02dfa52857ff118fde88e4faa",
+        "strip_prefix": "container-structure-test-1.16.0",
+        "urls": ["https://github.com/GoogleContainerTools/container-structure-test/archive/v1.16.0.zip"],
     },
 }
 


### PR DESCRIPTION
Added a temporary implementation of container_structure_test to //process/entrypoint.
Useful when testing the behavior of a process with pid 1.

Updates #143