### PR TITLE
ci: skip no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' && matrix.profile == 'release' }}
 
       - name: Run prek
-        run: nix develop --command prek run --show-diff-on-failure --color=always
+        run: nix develop --command prek run --skip no-commit-to-branch --show-diff-on-failure --color=always
 
       - name: Run cargo fmt
         run: nix develop --command cargo fmt --all --check


### PR DESCRIPTION
Add --skip no-commit-to-branch so the hook is bypassed in CI.

The no-commit-to-branch hook prevents direct commits to main.
When CI runs on pushes to main, prek checks out the code on
the main branch and this hook fires, causing CI to fail.
