### PR TITLE
chore: pin nixpkgs to a specific commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,17 +24,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773507054,
-        "narHash": "sha256-Q8U5VXgrcxmCxPtCCJCIZkcAX3FCZwGh1GNVIXxMND0=",
+        "lastModified": 1774243609,
+        "narHash": "sha256-6sB2IYqXYwoQS11Ev0u3b0lpAleTpvNv5iv4iqiCCR8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e80236013dc8b77aa49ca90e7a12d86f5d8d64c9",
+        "rev": "4724d5647207377bede08da3212f809cbd94a648",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "4724d5647207377bede08da3212f809cbd94a648",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/4724d5647207377bede08da3212f809cbd94a648"; # 2026-03-23
     fenix = {
       url = "github:nix-community/fenix/monthly";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Pins nixpkgs to a specific commit instead of tracking nixpkgs-unstable,
ensuring reproducible builds regardless of upstream changes.

- `flake.nix`: change `nixpkgs-unstable` to commit `4724d56` (2026-03-23)
- `flake.lock`: updated to reflect pinned revision
