### PR TITLE
chore: add github-cli to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,8 @@
         {
           default = pkgs.mkShellNoCC {
             packages = with pkgs; [
+              # GitHub client
+              github-cli
               # rust
               rust-toolchain
               rust-analyzer


### PR DESCRIPTION
Adds gh to the Nix dev shell so it's available
without a separate install.
