### PR TITLE
chore: use bazel-managed venv in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,9 +65,7 @@
               rust-toolchain
               rust-analyzer
               # python
-              python
               basedpyright
-              python.pkgs.uv
               python.pkgs.ruff
               # protobuf
               protobuf
@@ -82,6 +80,11 @@
             env = {
               RUST_SRC_PATH = "${pkgs.rust-toolchain}/lib/rustlib/src/rust/library";
             };
+
+            shellHook = ''
+              [[ -d .venv ]] || bazel run //:create_venv
+              source .venv/bin/activate
+            '';
           };
         }
       );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
   "pydantic==2.12",
 ]
 
-[tools.uv]
+[tool.uv]
 python-downloads = "never"
 python-preference = "only-system"
 


### PR DESCRIPTION
Remove `python` and `python.pkgs.uv` from
the Nix dev shell's explicit package list.
These are now provided transitively via Bazel's
`create_venv` target.

Add a `shellHook` that auto-creates `.venv`
via `bazel run //:create_venv` if it doesn't exist.
Then activates it on `nix develop`.

The Python environment is managed by Bazel,
which pins dependencies through `requirements.txt`.
Having `python` and `uv` also declared in the Nix shell
created a redundant, potentially diverging second
source of truth. The `shellHook` bridges the two:
- Nix handles the dev shell entry point
- Bazel owns the venv setup
