### PR TITLE
chore: add Claude Code configuration

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
+.claude
 .direnv

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,10 +48,11 @@ Body:
 * Bullet points are okay. Typically a hyphen or asterisk is
   used for the bullet, followed by a single space.
   Use a hanging indent.
-* If the PR is related to a GitHub issue, include a reference
-  at the end of the body. Skip this if the issue is unknown.
-  - `Fixes #123` — bug fix; closes the issue on merge.
-  - `Closes #123` — closes the issue on merge.
-  - `Resolves #123` — closes the issue on merge.
-  - `Part of #123` — partial progress; does not close the issue.
-  - `Related to #123` — related but does not close the issue.
+
+Footnotes (optional, skip if the issue is unknown):
+
+* `Fixes #123` — bug fix; closes the issue on merge.
+* `Closes #123` — closes the issue on merge.
+* `Resolves #123` — closes the issue on merge.
+* `Part of #123` — partial progress; does not close the issue.
+* `Related to #123` — related but does not close the issue.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## Instructions
+
+### General
+
+Write comments/documents in English, in complete sentences with correct punctuation.
+Keep text short and brief.
+
+### Dev environment
+
+The shell environment is managed by Nix. Enter it with:
+
+```sh
+nix develop ./nix
+# or, if direnv is configured, just `cd` into the repository.
+```
+
+This activates all the toolchains you need.
+
+### Pull requests
+
+PRs are squash-merged, so the PR title and body become the commit message in `git log`. Write them as if they are that commit message.
+
+Title:
+
+```
+<type>: <description>
+```
+
+* `<type>` consists of lowercase letters and classifies the PR.
+  e.g., Bazel package name, `ci`, `bazel`, `chore`
+* Uses the verb tense + phrase that completes the blank in:
+  "This change modifies the project to ___________"
+* Lowercase the verb.
+* No trailing period.
+* Keep the title short.
+
+For example, `nix: add terraform to manage cloud resources`.
+
+Body:
+
+* Explain what and why, not how.
+* Write in complete sentences with correct punctuation.
+* No HTML, Markdown, or any other markup language.
+* Bullet points are okay. Typically a hyphen or asterisk is
+  used for the bullet, followed by a single space.
+  Use a hanging indent.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,16 +22,17 @@ This activates all the toolchains you need.
 
 ### Pull requests
 
-PRs are squash-merged, so the PR title and body become the commit message in `git log`. Write them as if they are that commit message.
+PRs are squash-merged, so the PR title and body become the commit message in `git log`.
+Write them as if they are that commit message.
 
 Title:
 
 ```
-<type>: <description>
+<area>: <description>
 ```
 
-* `<type>` consists of lowercase letters and classifies the PR.
-  e.g., Bazel package name, `ci`, `bazel`, `chore`
+* `<area>` identifies the part of the codebase being changed.
+  e.g., a Bazel package name, `ci`, `nix`, `chore`
 * Uses the verb tense + phrase that completes the blank in:
   "This change modifies the project to ___________"
 * Lowercase the verb.
@@ -49,10 +50,47 @@ Body:
   used for the bullet, followed by a single space.
   Use a hanging indent.
 
-Footnotes (optional, skip if the issue is unknown):
+Footnotes (optional, skip if the issue number is unknown):
 
 * `Fixes #123` — bug fix; closes the issue on merge.
 * `Closes #123` — closes the issue on merge.
-* `Resolves #123` — closes the issue on merge.
 * `Part of #123` — partial progress; does not close the issue.
 * `Related to #123` — related but does not close the issue.
+
+### Issues
+
+Title:
+
+```
+<area>: <description>
+```
+
+* `<area>` identifies the part of the codebase the issue belongs to,
+  same as pull requests.
+* No trailing period.
+
+Use labels to classify the nature of the issue:
+
+* `bug` — something is broken.
+* `enhancement` — improvement to existing functionality.
+* `idea` — new project or concept to explore.
+
+For body, write in complete sentences with correct punctuation.
+Markdown is allowed.
+
+Bug (`bug`):
+
+* Describe the problem and why it matters.
+* Steps to reproduce.
+* Expected behavior and actual behavior.
+
+Enhancement (`enhancement`):
+
+* Describe the improvement and why it matters.
+* Current behavior and desired behavior.
+
+Idea (`idea`):
+
+* What the new project or concept is.
+* Why it is worth exploring.
+* Any rough thoughts on scope or direction.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,8 +6,13 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 ### General
 
-Write comments/documents in English, in complete sentences with correct punctuation.
+Write comments/documents in English.
 Keep text short and brief.
+
+Prefer ASCII. Avoid non-ASCII characters such as:
+- em dashes (—)
+- curly quotes ("“”")
+- ellipses (…)
 
 ### Dev environment
 
@@ -19,78 +24,3 @@ nix develop ./nix
 ```
 
 This activates all the toolchains you need.
-
-### Pull requests
-
-PRs are squash-merged, so the PR title and body become the commit message in `git log`.
-Write them as if they are that commit message.
-
-Title:
-
-```
-<area>: <description>
-```
-
-* `<area>` identifies the part of the codebase being changed.
-  e.g., a Bazel package name, `ci`, `nix`, `chore`
-* Uses the verb tense + phrase that completes the blank in:
-  "This change modifies the project to ___________"
-* Lowercase the verb.
-* No trailing period.
-* Keep the title short.
-
-For example, `nix: add terraform to manage cloud resources`.
-
-Body:
-
-* Explain what and why, not how.
-* Write in complete sentences with correct punctuation.
-* No HTML, Markdown, or any other markup language.
-* Bullet points are okay. Typically a hyphen or asterisk is
-  used for the bullet, followed by a single space.
-  Use a hanging indent.
-
-Footnotes (optional, skip if the issue number is unknown):
-
-* `Fixes #123` — bug fix; closes the issue on merge.
-* `Closes #123` — closes the issue on merge.
-* `Part of #123` — partial progress; does not close the issue.
-* `Related to #123` — related but does not close the issue.
-
-### Issues
-
-Title:
-
-```
-<area>: <description>
-```
-
-* `<area>` identifies the part of the codebase the issue belongs to,
-  same as pull requests.
-* No trailing period.
-
-Use labels to classify the nature of the issue:
-
-* `bug` — something is broken.
-* `enhancement` — improvement to existing functionality.
-* `idea` — new project or concept to explore.
-
-For body, write in complete sentences with correct punctuation.
-Markdown is allowed.
-
-Bug (`bug`):
-
-* Describe the problem and why it matters.
-* Steps to reproduce.
-* Expected behavior and actual behavior.
-
-Enhancement (`enhancement`):
-
-* Describe the improvement and why it matters.
-* Current behavior and desired behavior.
-
-Idea (`idea`):
-
-* What the new project or concept is.
-* Why it is worth exploring.
-* Any rough thoughts on scope or direction.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,3 +48,10 @@ Body:
 * Bullet points are okay. Typically a hyphen or asterisk is
   used for the bullet, followed by a single space.
   Use a hanging indent.
+* If the PR is related to a GitHub issue, include a reference
+  at the end of the body. Skip this if the issue is unknown.
+  - `Fixes #123` — bug fix; closes the issue on merge.
+  - `Closes #123` — closes the issue on merge.
+  - `Resolves #123` — closes the issue on merge.
+  - `Part of #123` — partial progress; does not close the issue.
+  - `Related to #123` — related but does not close the issue.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,72 @@
+Create or update a GitHub issue.
+
+## Conventions
+
+**Title:** a short description, no trailing period.
+
+**Label:** one of the following:
+
+* `bug`: something is broken.
+* `enhancement`: improvement to existing functionality.
+* `idea`: new project or concept to explore.
+
+**Body:** complete sentences, correct punctuation, Markdown allowed.
+
+Bug:
+
+* What is broken.
+* Why it matters.
+* Steps to reproduce.
+* Expected vs. actual behavior.
+
+Enhancement:
+
+* What to improve.
+* Why it matters.
+* Current vs. desired behavior.
+
+Idea:
+
+* What the project or concept is.
+* Why it matters.
+* Rough thoughts on scope or direction.
+
+## Steps
+
+### 1. Determine the action
+
+If an issue number is provided (e.g. `/issue 123`), update that issue.
+Otherwise, create a new issue.
+
+### 2. Gather context
+
+Run in parallel:
+
+- `gh issue list` to check for existing related issues.
+- If updating, `gh issue view <number>` to read the current issue.
+
+### 3. Draft the title and body
+
+Follow the conventions above.
+
+### 4. Create or update the issue
+
+If creating:
+
+```bash
+gh issue create \
+  --title "<title>" \
+  --label "<label>" \
+  --body "<body>"
+```
+
+If updating:
+
+```bash
+gh issue edit <number> \
+  --title "<title>" \
+  --label "<label>" \
+  --body "<body>"
+```
+
+### 5. Return the issue URL

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,41 @@
-Create or update the pull request for the current branch following the conventions in CLAUDE.md.
+Create or update the pull request for the current branch.
+
+## Conventions
+
+PRs are squash-merged, so the PR title and body become the commit message in `git log`.
+Write them as if they are that commit message.
+
+Title:
+
+```
+<area>: <description>
+```
+
+* `<area>` identifies the part of the codebase being changed.
+  e.g., a Bazel package name, `ci`, `nix`, `chore`
+* Uses the verb tense + phrase that completes the blank in:
+  "This change modifies the project to ___________"
+* Lowercase the verb.
+* No trailing period.
+* Keep the title short.
+
+For example, `nix: add terraform to manage cloud resources`.
+
+Body:
+
+* Explain what and why, not how.
+* Write in complete sentences with correct punctuation.
+* No HTML, Markdown, or any other markup language.
+* Bullet points are okay. Typically a hyphen or asterisk is
+  used for the bullet, followed by a single space.
+  Use a hanging indent.
+
+Footnotes (optional, skip if the issue number is unknown):
+
+* `Fixes #123`: bug fix; closes the issue on merge.
+* `Closes #123`: closes the issue on merge.
+* `Part of #123`: partial progress; does not close the issue.
+* `Related to #123`: related but does not close the issue.
 
 ## Steps
 
@@ -15,7 +52,7 @@ Otherwise default to `main`.
 
 ### 3. Draft the title and body
 
-Follow the Pull requests section of CLAUDE.md.
+Follow the conventions above.
 
 ### 4. Push the branch
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -17,7 +17,13 @@ Otherwise default to `main`.
 
 Follow the Pull requests section of CLAUDE.md.
 
-### 4. Create or update the PR
+### 4. Push the branch
+
+```bash
+git push -u origin HEAD
+```
+
+### 5. Create or update the PR
 
 If no PR exists:
 
@@ -37,4 +43,4 @@ gh pr edit \
   --body "<body>"
 ```
 
-### 5. Return the PR URL
+### 6. Return the PR URL

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,40 @@
+Create or update the pull request for the current branch following the conventions in CLAUDE.md.
+
+## Steps
+
+### 1. Determine the base branch
+
+Use the branch specified in the argument if provided (e.g. `/pr main`).
+Otherwise default to `main`.
+
+### 2. Run these in parallel
+
+- `git log <base branch>..HEAD`
+- `git diff <base branch>...HEAD`
+- `gh pr view --json url,title,body` to check if a PR already exists for this branch.
+
+### 3. Draft the title and body
+
+Follow the Pull requests section of CLAUDE.md.
+
+### 4. Create or update the PR
+
+If no PR exists:
+
+```bash
+gh pr create \
+  --draft \
+  --base <base branch> \
+  --title "<title>" \
+  --body "<body>"
+```
+
+If a PR already exists:
+
+```bash
+gh pr edit \
+  --title "<title>" \
+  --body "<body>"
+```
+
+### 5. Return the PR URL

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr view *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git status *)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean*)",
+      "Read(.env)"
+    ]
+  }
+}


### PR DESCRIPTION
Add .claude/CLAUDE.md to document coding conventions and dev environment setup for Claude Code.

Add /pr and /issue slash commands that create or update PRs and issues following project conventions.

Add .claude/settings.json with a permission allowlist for safe read-only git and GitHub commands and a denylist for destructive operations.

Add .claude to .bazelignore so Bazel does not traverse the directory.