### PR TITLE
syx: add namespace directory

### DIFF
--- a/syx/README.md
+++ b/syx/README.md
@@ -1,0 +1,3 @@
+# syx
+
+Short alias for the `symplectix` namespace.


### PR DESCRIPTION
Adds a syx/ directory as the top-level namespace for all first-party
code. The name syx is a short alias for symplectix, keeping Bazel
labels and Python import paths concise.