### PR TITLE
ci: fix prek base SHA reachability and cache strategy

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -31,6 +31,11 @@ runs:
         key: bazel-disk-${{ runner.os }}-${{ github.sha }}
         restore-keys: bazel-disk-${{ runner.os }}-
 
+    - name: Fetch base SHA
+      if: ${{ inputs.base-sha != '' }}
+      shell: bash
+      run: git fetch --depth=1 origin "${{ inputs.base-sha }}"
+
     - name: Pre-build
       if: ${{ inputs.base-sha != '' }}
       shell: nix develop ./nix#ci --command bash --noprofile --norc -eo pipefail {0}

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -5,9 +5,6 @@ inputs:
   base-sha:
     description: Base SHA used to narrow down affected targets.
     default: ''
-  head-sha:
-    description: Head SHA used to narrow down affected targets.
-    default: ''
   save-cache:
     description: Save caches after build ('true' or 'false').
     default: 'false'
@@ -41,9 +38,8 @@ runs:
       shell: nix develop ./nix#ci --command bash --noprofile --norc -eo pipefail {0}
       env:
         BASE_SHA: ${{ inputs.base-sha }}
-        HEAD_SHA: ${{ inputs.head-sha }}
       run: |
-        prek run --group ci --no-group no-ci --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA" --show-diff-on-failure --color=always
+        prek run --group ci --no-group no-ci --from-ref "$BASE_SHA" --show-diff-on-failure --color=always
 
     - name: Build
       shell: nix develop ./nix#ci --command bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -1,12 +1,12 @@
 name: Postsubmit
 
 on:
+  workflow_dispatch:
   # Verifies the merged state on main and populates caches. merge_group tests
   # a virtual merge; this run catches any divergence on the actual commit.
   push:
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,11 +33,18 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
+      - name: Compute fetch depth
+        env:
+          COMMITS: ${{ toJSON(github.event.commits) }}
+        run: |
+          count=$(echo "$COMMITS" | jq 'if . == null then 0 else length end')
+          echo "FETCH_DEPTH=$((count + 1))" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - uses: ./.github/actions/setup
         with:
@@ -45,6 +52,7 @@ jobs:
 
       - uses: ./.github/actions/check
         with:
+          # github.event.before is empty on workflow_dispatch.
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}
           save-cache: 'true'

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           # github.event.before is empty on workflow_dispatch.
           base-sha: ${{ github.event.before }}
-          head-sha: ${{ github.sha }}
           save-cache: 'true'
 
       - uses: ./.github/actions/cargo

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read # Allow reading contents.
@@ -33,18 +33,10 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - name: Compute fetch depth
-        env:
-          COMMITS: ${{ toJSON(github.event.commits) }}
-        run: |
-          count=$(echo "$COMMITS" | jq 'if . == null then 0 else length end')
-          echo "FETCH_DEPTH=$((count + 1))" >> "$GITHUB_ENV"
-
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -49,9 +49,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          # fetch-depth: 2 ensures the base SHA is reachable. A PR merge
-          # commit has the base SHA as its direct parent, so depth 2 is sufficient.
-          fetch-depth: 2
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -28,8 +28,8 @@ jobs:
         env:
           GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
 
-  check:
-    name: Check
+  ci:
+    name: CI
 
     strategy:
       matrix:
@@ -61,11 +61,7 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           head-sha: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-          # Save only from merge_group: the key is content-based, so PRs would create
-          # redundant entries; merge_group builds populate the cache for postsubmit.
-          save-cache: ${{ github.event_name == 'merge_group' }}
 
       - uses: ./.github/actions/cargo
         with:
           profile: ${{ matrix.profile }}
-          save-cache: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -57,7 +57,6 @@ jobs:
       - uses: ./.github/actions/check
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          head-sha: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
       - uses: ./.github/actions/cargo
         with:


### PR DESCRIPTION
postsubmit was failing with a git revision range error because
github.event.before was not reachable in the shallow clone. The root
cause is that the merge queue is configured with a maximum batch size of
5 PRs, so a single push to main can contain multiple commits, making
fetch-depth: 2 insufficient.

- Move base SHA reachability into check/action.yml by fetching the exact
  commit with git fetch --depth=1 origin <sha> before invoking prek.
  This is reliable regardless of how many commits were pushed and removes
  the need for callers to reason about fetch depth.

- Drop head-sha from the check action and all callers. prek defaults
  --to-ref to HEAD when only --from-ref is given. For PR events, HEAD is
  the synthetic merge commit that actions/checkout checks out, which
  already incorporates the PR changes relative to the base. Passing
  head-sha explicitly required fetching an additional commit not present
  in the default shallow clone.

- Remove fetch-depth from both presubmit and postsubmit checkouts since
  the action now handles reachability itself.

- In postsubmit, pass github.event.before as base-sha so prek checks
  exactly what changed since the last push to main.

- Stop saving caches from merge_group in presubmit. GitHub Actions cache
  scoping only allows main-branch caches to be read by other branches,
  so cache entries written from the ephemeral merge_group branch were
  never reachable by subsequent runs. Postsubmit saves caches
  unconditionally and is the correct place to do so.

- Set cancel-in-progress: false in postsubmit. Postsubmit is now the
  sole cache writer, so cancelling an in-flight run before it reaches
  the save-cache steps would leave all subsequent runs with cold caches.